### PR TITLE
Utilisation des répertoires de config définis ou connus pour les OS

### DIFF
--- a/source/UTILS_Fichiers.py
+++ b/source/UTILS_Fichiers.py
@@ -9,6 +9,7 @@
 #------------------------------------------------------------------------
 
 import os
+import sys
 
 
 def GetRepTemp(fichier=""):
@@ -24,30 +25,27 @@ def GetRepUtilisateur(fichier=""):
     """'safer' function to find user path."""
     chemin = None
 
-    try:
-        path = os.path.expanduser("~")
-        if os.path.isdir(path):
+    # Variable d'environnement
+    for evar in ('XDG_CONFIG_HOME', 'LOCALAPPDATA', 'APPDATA'):
+        path = os.environ.get(evar, None)
+        if path and os.path.isdir(path):
             chemin = path
-    except:
-        pass
+            break
+    if not chemin:
+        # ... ou répertoire de l'utilisateur
+        path = os.path.expanduser("~")
+        if path != "~" and os.path.isdir(path):
+            if sys.platform.startswith('linux'):
+                chemin = os.path.join(path, '.config')
+            else:
+                chemin = path
+        # ... ou dossier courrant.
+        else:
+            chemin = os.path.dirname(os.path.abspath(__file__))
 
-    # Autre méthode
-    if chemin == None :
-        for evar in ('HOME', 'USERPROFILE', 'TMP'):
-            try:
-                path = os.environ[evar]
-                if os.path.isdir(path):
-                    chemin = path
-                    break
-            except:
-                pass
-
-    if chemin == None :
-        chemin = os.path.dirname(os.path.abspath(__file__))
-
-    # Création du répertoire noethys si besoin
+    # Ajoute 'noethys' dans le chemin et création du répertoire
     chemin = os.path.join(chemin, "noethys")
-    if os.path.isdir(chemin) == False :
+    if not os.path.isdir(chemin):
         os.mkdir(chemin)
 
     # Ajoute le dirname si besoin


### PR DESCRIPTION
Au lieu d'utiliser le dossier personnel de l'utilisateur en premier, les répertoires de configuration connus pour les différents OS et définies dans les variables d'environnement sont d'abord cherchés/utilisés, dans cet ordre :
 * indépendamment du système : `XDG_CONFIG_HOME` (voir les [spécifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html))
 * spécifique à Window$ :
   * `LOCALAPPDATA` : qui correspond à `RootDrive:\User\<LoggedInUser>\AppData\Local`
   * `APPDATA` : qui correspond à `RootDrive:\User\<LoggedInUser>\AppData\Roaming`

Si rien n'est trouvé, alors le dossier personnel de l'utilisateur sera utilisé (avec la particularité sous GNU/Linux d'utiliser malgré tout le dossier `~/.config`), ou alors le dossier contenant le fichier s'il n'existe pas.

Enfin, un dossier `noethys` sera créé dans ce dossier et sera utilisé.