### PR TITLE
Défini une année nulle par défaut dans le fichier de configuration

### DIFF
--- a/source/UTILS_Config.py
+++ b/source/UTILS_Config.py
@@ -35,7 +35,7 @@ def GenerationFichierConfig():
                 'modeAffichage': 'nbrePlacesPrises',
                 'dateDebut': None,
                 'dateFin': None,
-                'annee': 2011,
+                'annee': None,
                 'page': 0,
                 },
         "assistant_demarrage" : False,


### PR DESCRIPTION
... afin d'utiliser l'année courante dans les différentes vues, c'est plus pratique ! :)