### PR TITLE
Utilise le répertoire utilisateur pour les données

### DIFF
--- a/source/UTILS_Fichiers.py
+++ b/source/UTILS_Fichiers.py
@@ -32,10 +32,6 @@ def GetRepData(fichier=""):
     if chemin != "" and os.path.isdir(chemin):
         return os.path.join(chemin, fichier)
 
-    # Recherche le chemin du répertoire des données
-    chemin = appdirs.site_data_dir(appname=None, appauthor=False, multipath=False)
-    chemin = chemin.decode("iso-8859-15")
-
     if platform.release() == "Vista" :
 
         # Création du répertoire Data s'il n'existe pas
@@ -45,8 +41,11 @@ def GetRepData(fichier=""):
 
     else :
 
-        # Ajoute 'noethys' dans le chemin et création du répertoire
-        chemin = os.path.join(chemin, "noethys")
+        # Recherche le chemin du répertoire des données pour noethys
+        chemin = appdirs.user_data_dir(appname="noethys", appauthor=False)
+        chemin = chemin.decode("iso-8859-15")
+
+        # Création du répertoire s'il n'existe pas
         if not os.path.isdir(chemin):
             os.mkdir(chemin)
 


### PR DESCRIPTION
Comme signalé ici https://github.com/Noethys/Noethys/pull/6#issuecomment-218298376, l'utilisation du répertoire système pour les données est problématique pour les systèmes *nix du fait des permissions insuffisantes de l'utilisateur sur le dossier `/usr/local/share`. Ce commit permet d'utiliser le répertoire utilisateur à la place.

Plus d'informations sur ces répertoires :
 * répertoire système : https://github.com/ActiveState/appdirs/blob/master/appdirs.py#L120-L125
 * répertoire utilisateur : https://github.com/ActiveState/appdirs/blob/master/appdirs.py#L66-L72

Je pense que ça devrait être le comportement par défaut (répertoire utilisateur), et qu'il devrait être proposé dans l'interface (s'il est accessible) d'utiliser le répertoire partagé du système, car cela requiert des permissions utilisateur supplémentaires sous les systèmes *nix, qui devra être réglé par le paquet pour la distribution.