### PR TITLE
Vérifie si la base de données est vide lors du test de connexion

### DIFF
--- a/noethys/GestionDB.py
+++ b/noethys/GestionDB.py
@@ -2049,7 +2049,14 @@ def TestConnexionMySQL(typeTest="fichier", nomFichier=""):
             if nomFichier in listeDatabases :
                 # Ouverture Database
                 cursor.execute("USE %s;" % nomFichier)
-                dictResultats["fichier"] =  (True, None)
+                # Vérification des tables
+                cursor.execute("SHOW TABLES;")
+                listeTables = cursor.fetchall()
+                if not listeTables:
+                    dictResultats["fichier"] = (
+                        False, _(u"La base de données est vide."))
+                else:
+                    dictResultats["fichier"] =  (True, None)
             else:
                 dictResultats["fichier"] =  (False, _(u"Accès au fichier impossible."))
         except Exception, err :


### PR DESCRIPTION
Dans le cas d'une utilisation *réseau*, et plus particulièrement dans la fonction `TestConnexionMySQL`, une base de données existante mais vide n'est pas différenciée. C'est particulièrement bloquant lors de la création d'un *fichier réseau*, qui se base sur cette fonction pour déterminer si *le fichier existe déjà*. Or, le fait de créer en amont les bases de données permet d'éviter de spécifier le super-utilisateur MySQL `root`.

Cette PR ajoute donc un test supplémentaire dans `TestConnexionMySQL` afin de différencier une base de données vide d'une avec des tables déjà existantes. Cela rend de ce fait possible la création d'un *fichier réseau* en créant au préalables les bases de données nécessaires (`<nom-fichier>_data`, `<nom-fichier>_photos` et `<nom-fichier>_documents`), et en spécifiant un utilisateur n'ayant que les droits sur ces dernières.