### PR TITLE
Optimise la recherche dans la liste des individus

### DIFF
--- a/noethys/Ctrl/CTRL_Recherche_individus.py
+++ b/noethys/Ctrl/CTRL_Recherche_individus.py
@@ -200,7 +200,7 @@ class Panel(wx.Panel):
         self.Layout()
         
     def MAJ(self):
-        self.ctrl_listview.MAJ()
+        self.ctrl_listview.MAJ(forceActualisation=True)
         
     def Aide(self):
         from Utils import UTILS_Aide

--- a/noethys/Ol/OL_Individus.py
+++ b/noethys/Ol/OL_Individus.py
@@ -326,10 +326,8 @@ class ListView(FastObjectListView):
         
         # MAJ
         self.forceActualisation = forceActualisation
-        donnees = self.GetTracks()
-        self.forceActualisation = False
-        if donnees != None :
-            self.donnees = donnees
+        if not self.donnees or forceActualisation:
+            self.donnees = self.GetTracks()
             self.GetParent().Freeze() 
             self.InitObjectListView()
             self.GetParent().Thaw() 


### PR DESCRIPTION
Lorsque de nombreux individus sont définis, en plus en utilisant une base MySQL, le filtre sur la liste des individus en page d'accueil est relativement long. Vu que pour chaque lettre, la liste est à nouveau
récupérée en base, cela ralentit considérablement la recherche.

Afin d'optimiser la recherche, la liste des individus n'est récupérée en base que quand c'est nécessaire ou demandé, et non à chaque mise à jour.