### PR TITLE
Ajoute un panneau pour filtrer l'école dans le gestionnaire de conso.

### DIFF
--- a/noethys/Ctrl/CTRL_Grille_ecoles.py
+++ b/noethys/Ctrl/CTRL_Grille_ecoles.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Auteurs:         Ivan LUCAS, Cliss XXI
+# Copyright:       (c) 2010-11 Ivan LUCAS
+#                  (c) 2017 Cliss XXI
+# Licence:         Licence GNU GPL
+#-----------------------------------------------------------
+
+import datetime
+
+import wx
+import wx.lib.agw.hypertreelist as HTL
+from wx.lib.agw.customtreectrl import EVT_TREE_ITEM_CHECKED
+
+import Chemins # noqa
+import GestionDB
+from Utils import UTILS_Dates
+from Utils.UTILS_Traduction import _
+
+
+class CTRL(HTL.HyperTreeList):
+    def __init__(self, parent):
+        HTL.HyperTreeList.__init__(self, parent, -1)
+        self.parent = parent
+        self.date = None
+        self.dictEcoles = {}
+        self.MAJenCours = False
+        self.cocherParDefaut = True
+        self.cocheInconnue = True
+        self.cochesActives = {}
+        self.cochesEcolesActives = set()
+
+        self.SetBackgroundColour(wx.WHITE)
+        self.SetAGWWindowStyleFlag(
+            HTL.TR_NO_HEADER | wx.TR_HIDE_ROOT | wx.TR_HAS_BUTTONS |
+            wx.TR_HAS_VARIABLE_ROW_HEIGHT | wx.TR_FULL_ROW_HIGHLIGHT
+        )
+        self.EnableSelectionVista(True)
+
+        self.SetToolTipString(_(u"Cochez les écoles et classes à afficher"))
+
+        # Création des colonnes
+        self.AddColumn(_(u"Ecole/classe"))
+        self.SetColumnWidth(0, 420)
+
+        # Binds
+        self.Bind(EVT_TREE_ITEM_CHECKED, self.OnCheckItem)
+
+    def SetDate(self, date=None):
+        self.date = date
+        self.MAJ()
+
+    def SetCocherParDefaut(self, etat=True):
+        self.cocherParDefaut = etat
+
+    def OnCheckItem(self, event):
+        if self.MAJenCours is False:
+            item = event.GetItem()
+            data = self.GetPyData(item)
+            # Active ou non les branches enfants
+            if data["type"] == "ecole":
+                if self.IsItemChecked(item):
+                    self.EnableChildren(item, True)
+                    self.cochesEcolesActives.add(data["ID"])
+                else:
+                    self.EnableChildren(item, False)
+                    self.cochesEcolesActives.discard(data["ID"])
+            elif data["type"] == "classe":
+                cochesGroupes = self.cochesActives[data["IDecole"]]
+                if self.IsItemChecked(item):
+                    cochesGroupes.add(data["ID"])
+                else:
+                    cochesGroupes.discard(data["ID"])
+            else:
+                self.cocheInconnue = self.IsItemChecked(item)
+            # Envoie les données aux contrôle parent
+            if hasattr(self.parent, "MAJecoles"):
+                self.parent.MAJecoles()
+
+    def Cocher(self, etat=True):
+        self.MAJenCours = True
+        item = self.root
+        for index in range(0, self.GetChildrenCount(self.root)):
+            item = self.GetNext(item)
+            self.CheckItem(item, etat)
+        self.MAJenCours = False
+
+    def CocheListeTout(self):
+        self.Cocher(True)
+
+    def CocheListeRien(self):
+        self.Cocher(False)
+
+    def MAJ(self):
+        """ Met à jour (redessine) tout le contrôle """
+        self.dictEcoles = self.Importation()
+        self.MAJenCours = True
+        self.DeleteAllItems()
+        self.root = self.AddRoot(_(u"Racine"))
+        self.Remplissage()
+        self.MAJenCours = False
+
+    def Importation(self):
+        dictEcoles = {}
+        if not self.date:
+            return dictEcoles
+
+        # Récupération des écoles disponibles le jour sélectionné
+        DB = GestionDB.DB()
+        req = """SELECT ecoles.IDecole, ecoles.nom,
+        classes.IDclasse, classes.nom, classes.niveaux,
+        classes.date_debut, classes.date_fin
+        FROM scolarite
+        LEFT JOIN ecoles ON ecoles.IDecole = scolarite.IDecole
+        LEFT JOIN classes ON classes.IDclasse = scolarite.IDclasse
+        WHERE scolarite.IDclasse IS NOT NULL
+              AND scolarite.date_debut<='{0}' AND scolarite.date_fin>='{0}'
+        GROUP BY scolarite.IDclasse;""".format(self.date)
+        DB.ExecuterReq(req)
+        listeDonnees = DB.ResultatReq()
+        DB.Close()
+
+        for (IDecole, nomEcole, IDclasse, nomClasse, niveaux,
+             date_debut, date_fin) in listeDonnees:
+            if date_debut is not None:
+                date_debut = UTILS_Dates.DateEngEnDateDD(date_debut)
+            if date_fin is not None:
+                date_fin = UTILS_Dates.DateEngEnDateDD(date_fin)
+
+            # Mémorisation de l'école
+            if IDecole not in dictEcoles:
+                dictEcoles[IDecole] = {"nom": nomEcole, "classes": []}
+
+            # Mémorisation de la classe
+            dictEcoles[IDecole]["classes"].append({
+                "IDclasse": IDclasse,
+                "nom": nomClasse,
+                "date_debut": date_debut,
+                "date_fin": date_fin
+            })
+
+        return dictEcoles
+
+    def Remplissage(self):
+        # Tri des écoles par nom
+        listeEcoles = []
+        for IDecole, dictEcole in self.dictEcoles.iteritems():
+            listeEcoles.append((dictEcole["nom"], IDecole))
+        listeEcoles.sort()
+
+        # Remplissage
+        for nomEcole, IDecole in listeEcoles:
+            dictEcole = self.dictEcoles[IDecole]
+
+            # Initialise l'état des coches pour l'école
+            if IDecole not in self.cochesActives:
+                if self.cocherParDefaut is True:
+                    self.cochesEcolesActives.add(IDecole)
+                    self.cochesActives[IDecole] = set([
+                        d["IDclasse"] for d in dictEcole["classes"]
+                    ])
+                else:
+                    self.cochesActives[IDecole] = set()
+
+            # Niveau Ecole
+            niveauEcole = self.AppendItem(self.root, nomEcole, ct_type=1)
+            self.SetPyData(niveauEcole, {
+                "type": "ecole",
+                "ID": IDecole,
+                "nom": nomEcole
+            })
+            self.SetItemBold(niveauEcole, True)
+
+            # Niveau Classes
+            for dictClasse in dictEcole["classes"]:
+                IDclasse = dictClasse["IDclasse"]
+                nomClasse = dictClasse["nom"]
+                label = u"{0} (du {1} au {2})".format(
+                    nomClasse,
+                    UTILS_Dates.DateEngFr(dictClasse["date_debut"]),
+                    UTILS_Dates.DateEngFr(dictClasse["date_fin"]),
+                )
+                niveauClasse = self.AppendItem(niveauEcole, label, ct_type=1)
+                self.SetPyData(niveauClasse, {
+                    "type": "classe",
+                    "ID": IDclasse,
+                    "nom": nomClasse,
+                    "IDecole": IDecole,
+                })
+
+                if IDclasse in self.cochesActives[IDecole]:
+                    self.CheckItem(niveauClasse)
+
+            # Coche l'école et active ses classes
+            if IDecole in self.cochesEcolesActives:
+                self.CheckItem(niveauEcole)
+                self.EnableChildren(niveauEcole, True)
+            else:
+                self.EnableChildren(niveauEcole, False)
+
+        # Ajoute une entrée pour les enfants dont la scolarité est inconnue
+        item = self.AppendItem(self.root, u"Scolarité inconnue", ct_type=1)
+        self.SetPyData(item, {"type": "inconnu"})
+        if self.cocheInconnue:
+            self.CheckItem(item)
+
+        self.ExpandAllChildren(self.root)
+
+    def GetCoches(self, typeTemp="ecole"):
+        listeCoches = []
+        item = self.root
+        for index in range(0, self.GetChildrenCount(self.root)):
+            item = self.GetNext(item)
+            if self.IsItemChecked(item) and self.IsItemEnabled(item):
+                data = self.GetPyData(item)
+                if data["type"] == typeTemp:
+                    listeCoches.append(data["ID"])
+        return listeCoches
+
+    def GetListeEcoles(self):
+        return self.GetCoches(typeTemp="ecole")
+
+    def GetListeClasses(self):
+        return self.GetCoches(typeTemp="classe")
+
+    def GetScolariteInconnue(self):
+        item = self.GetLastChild(self.root)
+        return self.IsItemChecked(item) and self.IsItemEnabled(item)
+
+    def GetDictEcoles(self):
+        return self.dictEcoles
+
+
+class MyFrame(wx.Frame):
+    def __init__(self, *args, **kwds):
+        wx.Frame.__init__(self, *args, **kwds)
+        panel = wx.Panel(self, -1)
+        sizer_1 = wx.BoxSizer(wx.VERTICAL)
+        sizer_1.Add(panel, 1, wx.ALL | wx.EXPAND)
+        self.SetSizer(sizer_1)
+        self.ctrl = CTRL(panel)
+        self.ctrl.MAJ()
+        sizer_2 = wx.BoxSizer(wx.VERTICAL)
+        sizer_2.Add(self.ctrl, 1, wx.ALL | wx.EXPAND, 4)
+        panel.SetSizer(sizer_2)
+        self.Layout()
+        self.CentreOnScreen()
+
+
+if __name__ == '__main__':
+    app = wx.App(0)
+    frame_1 = MyFrame(None, -1, _(u"TEST"), size=(800, 400))
+    frame_1.ctrl.SetDate(datetime.datetime.now())
+    app.SetTopWindow(frame_1)
+    frame_1.Show()
+    app.MainLoop()

--- a/noethys/Dlg/DLG_Gestionnaire_conso.py
+++ b/noethys/Dlg/DLG_Gestionnaire_conso.py
@@ -125,7 +125,7 @@ class Commandes(wx.Panel):
         grid_sizer_base.Add(self.bouton_ok, 0, 0, 0)
         grid_sizer_base.Add(self.bouton_annuler, 0, 0, 0)
         grid_sizer_base.AddGrowableCol(3)
-        sizer_base.Add(grid_sizer_base, 0, wx.ALL|wx.EXPAND, 10)
+        sizer_base.Add(grid_sizer_base, 0, wx.ALL | wx.EXPAND, 10)
         self.SetSizer(sizer_base)
         self.SetMinSize((-1, 50))
         self.Layout()
@@ -153,7 +153,7 @@ class Commandes(wx.Panel):
 
     def OnBoutonAnnuler(self, event):
         etat = self.parent.Annuler()
-        if etat == False :
+        if etat == False:
             return
         self.parent.EndModal(wx.ID_CANCEL)
 
@@ -262,22 +262,22 @@ class PanelGrille(wx.Panel):
         self.grille = CTRL_Grille.CTRL(self, "date")
 
         # Barre d'outils
-        self.barreOutils = wx.ToolBar(self, -1, style =
-            wx.TB_HORIZONTAL
-            | wx.NO_BORDER
-            | wx.TB_FLAT
-            | wx.TB_TEXT
-            | wx.TB_HORZ_LAYOUT
-            | wx.TB_NODIVIDER
-            )
+        self.barreOutils = wx.ToolBar(self, -1, style=(
+            wx.TB_HORIZONTAL |
+            wx.NO_BORDER |
+            wx.TB_FLAT |
+            wx.TB_TEXT |
+            wx.TB_HORZ_LAYOUT |
+            wx.TB_NODIVIDER
+        ))
         self.ctrl_recherche = CTRL_Grille.BarreRecherche(self.barreOutils, ctrl_grille=self.grille)
         self.barreOutils.AddControl(self.ctrl_recherche)
 
         self.barreOutils.AddLabelTool(ID_AJOUTER_INDIVIDU, label=_(u"Ajouter un individu"), bitmap=wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Femme.png"), wx.BITMAP_TYPE_PNG), shortHelp=_(u"Ajouter un individu"), longHelp=_(u"Ajouter un individu"))
         self.barreOutils.AddLabelTool(ID_AFFICHER_TOUS_INSCRITS, label=_(u"Afficher tous les inscrits"), bitmap=wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Famille.png"), wx.BITMAP_TYPE_PNG), shortHelp=_(u"Afficher tous les inscrits"), longHelp=_(u"Afficher tous les inscrits"))
-        try :
+        try:
             self.barreOutils.AddStretchableSpace()
-        except :
+        except:
             self.barreOutils.AddSeparator()
         self.barreOutils.AddRadioLabelTool(ID_MODE_RESERVATION, label=_(u"Réservation"), bitmap=CTRL_Grille.CreationImage(10, 20, CTRL_Grille.COULEUR_RESERVATION), shortHelp=_(u"Mode de saisie 'Réservation'"), longHelp=_(u"Mode de saisie 'Réservation'"))
         self.barreOutils.AddRadioLabelTool(ID_MODE_ATTENTE, label=_(u"Attente"), bitmap=CTRL_Grille.CreationImage(10, 20, CTRL_Grille.COULEUR_ATTENTE), shortHelp=_(u"Mode de saisie 'Attente'"), longHelp=_(u"Mode de saisie 'Attente'"))
@@ -291,7 +291,7 @@ class PanelGrille(wx.Panel):
         grid_sizer_base = wx.FlexGridSizer(rows=4, cols=1, vgap=0, hgap=0)
         grid_sizer_base.Add(self.ctrl_titre, 0, wx.EXPAND,  0)
         grid_sizer_base.Add(self.grille, 0, wx.EXPAND,  0)
-        grid_sizer_base.Add(self.barreOutils, 0, wx.EXPAND|wx.ALL,  5)
+        grid_sizer_base.Add(self.barreOutils, 0, wx.EXPAND | wx.ALL,  5)
         grid_sizer_base.AddGrowableCol(0)
         grid_sizer_base.AddGrowableRow(1)
         self.SetSizer(grid_sizer_base)
@@ -308,7 +308,7 @@ class PanelGrille(wx.Panel):
 
     def SetDate(self, date=None):
         self.date = date
-        if self.date == None :
+        if self.date == None:
             dateStr = u""
         else:
             dateStr = DateComplete(self.date)
@@ -322,14 +322,20 @@ class PanelGrille(wx.Panel):
 
     def GetListeIndividus(self):
         listeSelectionIndividus = []
-        # Conditions Activités :
-        if len(self.listeActivites) == 0 : conditionActivites = "()"
-        elif len(self.listeActivites) == 1 : conditionActivites = "(%d)" % self.listeActivites[0]
-        else : conditionActivites = str(tuple(self.listeActivites))
+        # Conditions Activités
+        if len(self.listeActivites) == 0:
+            conditionActivites = "()"
+        elif len(self.listeActivites) == 1:
+            conditionActivites = "(%d)" % self.listeActivites[0]
+        else:
+            conditionActivites = str(tuple(self.listeActivites))
         # Condition Groupes
-        if len(self.listeGroupes) == 0 : conditionGroupes = ""
-        elif len(self.listeGroupes) == 1 : conditionGroupes = " AND IDgroupe=%d" % self.listeGroupes[0]
-        else : conditionGroupes = " AND IDgroupe IN %s" % str(tuple(self.listeGroupes))
+        if len(self.listeGroupes) == 0:
+            conditionGroupes = ""
+        elif len(self.listeGroupes) == 1:
+            conditionGroupes = " AND IDgroupe=%d" % self.listeGroupes[0]
+        else:
+            conditionGroupes = " AND IDgroupe IN %s" % str(tuple(self.listeGroupes))
 
         DB = GestionDB.DB()
         req = """SELECT IDindividu, COUNT(IDconso)
@@ -340,21 +346,21 @@ class PanelGrille(wx.Panel):
         DB.ExecuterReq(req)
         listeDonnees = DB.ResultatReq()
         DB.Close()
-        for IDindividu, nbreConsommations in listeDonnees :
+        for IDindividu, nbreConsommations in listeDonnees:
             listeSelectionIndividus.append(IDindividu)
 
         # On ajoute les individus ajoutés manuellement :
-        if self.dictIndividusAjoutes.has_key(self.date) :
-            for IDindividu in self.dictIndividusAjoutes[self.date] :
+        if self.dictIndividusAjoutes.has_key(self.date):
+            for IDindividu in self.dictIndividusAjoutes[self.date]:
                 valide = False
-                if self.grille.dictConsoIndividus.has_key(IDindividu) :
-                    if self.grille.dictConsoIndividus[IDindividu].has_key(self.date) :
+                if self.grille.dictConsoIndividus.has_key(IDindividu):
+                    if self.grille.dictConsoIndividus[IDindividu].has_key(self.date):
                         # Vérifie que l'individu a des conso pour la ou les groupes sélectionnés
-                        for IDunite, listeConso in self.grille.dictConsoIndividus[IDindividu][self.date].iteritems() :
-                            for conso in listeConso :
-                                if conso.IDgroupe in self.listeGroupes :
+                        for IDunite, listeConso in self.grille.dictConsoIndividus[IDindividu][self.date].iteritems():
+                            for conso in listeConso:
+                                if conso.IDgroupe in self.listeGroupes:
                                     valide = True
-                if valide == True and IDindividu not in listeSelectionIndividus :
+                if valide == True and IDindividu not in listeSelectionIndividus:
                     listeSelectionIndividus.append(IDindividu)
 
         return listeSelectionIndividus
@@ -366,31 +372,38 @@ class PanelGrille(wx.Panel):
         if dlg.ShowModal() == wx.ID_OK:
             IDindividu = dlg.GetIDindividu()
             # Recherche si l'individu est déjà dans la grille
-            if IDindividu in self.grille.listeSelectionIndividus :
+            if IDindividu in self.grille.listeSelectionIndividus:
                 dlg = wx.MessageDialog(self, _(u"L'individu que vous avez sélectionné est déjà dans la grille des présences !"), _(u"Erreur de saisie"), wx.OK | wx.ICON_EXCLAMATION)
                 dlg.ShowModal()
                 dlg.Destroy()
                 return
         dlg.Destroy()
-        if IDindividu == None : return
+        if IDindividu == None:
+            return
         self.listeSelectionIndividus.append(IDindividu)
         self.grille.SetModeDate(self.listeActivites, self.listeSelectionIndividus, self.date)
         # Ajout de l'individu dans une liste pour le garder afficher lors d'une MAJ de l'affichage
-        if self.dictIndividusAjoutes.has_key(self.date) == False :
+        if self.dictIndividusAjoutes.has_key(self.date) == False:
             self.dictIndividusAjoutes[self.date] = []
-        if IDindividu not in self.dictIndividusAjoutes[self.date] :
+        if IDindividu not in self.dictIndividusAjoutes[self.date]:
             self.dictIndividusAjoutes[self.date].append(IDindividu)
 
     def AfficherTousInscrits(self, event=None):
         """ Affiche tous les inscrits à l'activité """
-        # Conditions Activités :
-        if len(self.listeActivites) == 0 : conditionActivites = "()"
-        elif len(self.listeActivites) == 1 : conditionActivites = "(%d)" % self.listeActivites[0]
-        else : conditionActivites = str(tuple(self.listeActivites))
+        # Conditions Activités
+        if len(self.listeActivites) == 0:
+            conditionActivites = "()"
+        elif len(self.listeActivites) == 1:
+            conditionActivites = "(%d)" % self.listeActivites[0]
+        else:
+            conditionActivites = str(tuple(self.listeActivites))
         # Condition Groupes
-        if len(self.listeGroupes) == 0 : conditionGroupes = ""
-        elif len(self.listeGroupes) == 1 : conditionGroupes = " AND IDgroupe=%d" % self.listeGroupes[0]
-        else : conditionGroupes = " AND IDgroupe IN %s" % str(tuple(self.listeGroupes))
+        if len(self.listeGroupes) == 0:
+            conditionGroupes = ""
+        elif len(self.listeGroupes) == 1:
+            conditionGroupes = " AND IDgroupe=%d" % self.listeGroupes[0]
+        else:
+            conditionGroupes = " AND IDgroupe IN %s" % str(tuple(self.listeGroupes))
 
         DB = GestionDB.DB()
         req = """SELECT IDinscription, IDindividu
@@ -402,21 +415,24 @@ class PanelGrille(wx.Panel):
         listeDonnees = DB.ResultatReq()
         DB.Close()
 
-        for IDinscription, IDindividu in listeDonnees :
-            if IDindividu not in self.listeSelectionIndividus :
+        for IDinscription, IDindividu in listeDonnees:
+            if IDindividu not in self.listeSelectionIndividus:
                 self.listeSelectionIndividus.append(IDindividu)
                 # Ajout de l'individu dans une liste pour le garder afficher lors d'une MAJ de l'affichage
-                if self.dictIndividusAjoutes.has_key(self.date) == False :
+                if self.dictIndividusAjoutes.has_key(self.date) == False:
                     self.dictIndividusAjoutes[self.date] = []
-                if IDindividu not in self.dictIndividusAjoutes[self.date] :
+                if IDindividu not in self.dictIndividusAjoutes[self.date]:
                     self.dictIndividusAjoutes[self.date].append(IDindividu)
         # MAJ de l'affichage
         self.grille.SetModeDate(self.listeActivites, self.listeSelectionIndividus, self.date)
 
     def GetMode(self):
-        if self.barreOutils.GetToolState(ID_MODE_RESERVATION) == True : return "reservation"
-        if self.barreOutils.GetToolState(ID_MODE_ATTENTE) == True : return "attente"
-        if self.barreOutils.GetToolState(ID_MODE_REFUS) == True : return "refus"
+        if self.barreOutils.GetToolState(ID_MODE_RESERVATION) == True:
+            return "reservation"
+        if self.barreOutils.GetToolState(ID_MODE_ATTENTE) == True:
+            return "attente"
+        if self.barreOutils.GetToolState(ID_MODE_REFUS) == True:
+            return "refus"
 
 
 class Dialog(wx.Dialog):
@@ -430,9 +446,9 @@ class Dialog(wx.Dialog):
         # Détermine la taille de la fenêtre
         self.SetMinSize((700, 600))
         taille_fenetre = UTILS_Config.GetParametre("taille_fenetre_tableau_presences")
-        if taille_fenetre == None :
+        if taille_fenetre == None:
             self.SetSize((900, 600))
-        if taille_fenetre == (0, 0) :
+        if taille_fenetre == (0, 0):
             self.Maximize(True)
         else:
             self.SetSize(taille_fenetre)
@@ -441,11 +457,11 @@ class Dialog(wx.Dialog):
         # Récupère les perspectives
         cfg = UTILS_Config.FichierConfig()
         self.userConfig = cfg.GetDictConfig()
-        if self.userConfig.has_key("gestionnaire_perspectives") == True :
+        if self.userConfig.has_key("gestionnaire_perspectives") == True:
             self.perspectives = self.userConfig["gestionnaire_perspectives"]
         else:
             self.perspectives = []
-        if self.userConfig.has_key("gestionnaire_perspective_active") == True :
+        if self.userConfig.has_key("gestionnaire_perspective_active") == True:
             self.perspective_active = self.userConfig["gestionnaire_perspective_active"]
         else:
             self.perspective_active = None
@@ -514,19 +530,19 @@ class Dialog(wx.Dialog):
         self.perspective_defaut = self._mgr.SavePerspective()
 
         # Récupération de la perspective chargée
-        if self.perspective_active != None :
+        if self.perspective_active != None:
             self._mgr.LoadPerspective(self.perspectives[self.perspective_active]["perspective"])
         else:
             self._mgr.LoadPerspective(self.perspective_defaut)
 
         # Affichage du panneau du panneau Forfait Credits
-        if self.panel_grille.grille.tarifsForfaitsCreditsPresents == True :
+        if self.panel_grille.grille.tarifsForfaitsCreditsPresents == True:
             self._mgr.GetPane("forfaits").Show()
         else:
             self._mgr.GetPane("forfaits").Hide()
 
         # Affichage du panneau du panneau Etiquettes
-        if self.panel_grille.grille.afficherListeEtiquettes == True :
+        if self.panel_grille.grille.afficherListeEtiquettes == True:
             self._mgr.GetPane("etiquettes").Show()
         else:
             self._mgr.GetPane("etiquettes").Hide()
@@ -599,13 +615,13 @@ class Dialog(wx.Dialog):
     def OnClose(self, event):
         self.MemoriseParametres()
         etat = self.Annuler()
-        if etat == False :
+        if etat == False:
             return
         event.Skip()
 
     def MemoriseParametres(self):
         # Mémorisation du paramètre de la taille d'écran
-        if self.IsMaximized() == True :
+        if self.IsMaximized() == True:
             taille_fenetre = (0, 0)
         else:
             taille_fenetre = tuple(self.GetSize())
@@ -617,14 +633,14 @@ class Dialog(wx.Dialog):
         self.panel_grille.grille.MemoriseParametres()
 
     def Annuler(self):
-        if len(self.panel_grille.grille.listeHistorique) > 0 :
+        if len(self.panel_grille.grille.listeHistorique) > 0:
 #            texteHistorique = self.panel_grille.grille.GetTexteHistorique()
             dlg = wx.MessageDialog(self, _(u"Des modifications ont été effectuées dans la grille.\n\nSouhaitez-vous enregistrer ces modifications avant de fermer cette fenêtre ?"), _(u"Sauvegarde des modifications"), wx.YES_NO|wx.YES_DEFAULT|wx.CANCEL|wx.ICON_EXCLAMATION)
             reponse = dlg.ShowModal()
             dlg.Destroy()
-            if reponse == wx.ID_CANCEL :
+            if reponse == wx.ID_CANCEL:
                 return False
-            if reponse == wx.ID_YES :
+            if reponse == wx.ID_YES:
                 # Sauvegarde des données
                 self.panel_grille.grille.Sauvegarde()
             return True
@@ -698,12 +714,12 @@ class Dialog(wx.Dialog):
 
 
     def On_outils_imprimer(self, event):
-        if len(self.panel_grille.grille.listeHistorique) > 0 :
+        if len(self.panel_grille.grille.listeHistorique) > 0:
 ##            texteHistorique = self.panel_grille.grille.GetTexteHistorique()
             dlg = wx.MessageDialog(self, _(u"Des modifications ont été effectuées dans la grille.\n\nSouhaitez-vous les enregistrer maintenant afin qu'elles apparaissent dans le document ?"), _(u"Sauvegarde des modifications"), wx.YES_NO|wx.YES_DEFAULT|wx.CANCEL|wx.ICON_EXCLAMATION)
             reponse = dlg.ShowModal()
             dlg.Destroy()
-            if reponse != wx.ID_YES :
+            if reponse != wx.ID_YES:
                 return
 
             # Sauvegarde des données
@@ -719,11 +735,12 @@ class Dialog(wx.Dialog):
         dlg.Destroy()
 
     def On_outils_recalculer(self, event):
-        if UTILS_Utilisateurs.VerificationDroitsUtilisateurActuel("consommations_conso", "modifier") == False : return
+        if UTILS_Utilisateurs.VerificationDroitsUtilisateurActuel("consommations_conso", "modifier") == False:
+            return
         dlg = wx.MessageDialog(self, _(u"Confirmez-vous le recalcul des prestations de toutes les consommations affichées ?"), _(u"Recalcul des prestations"), wx.YES_NO|wx.NO_DEFAULT|wx.CANCEL|wx.ICON_QUESTION)
         reponse = dlg.ShowModal()
         dlg.Destroy()
-        if reponse != wx.ID_YES :
+        if reponse != wx.ID_YES:
             return
         self.panel_grille.grille.RecalculerToutesPrestations()
 
@@ -734,14 +751,16 @@ class Dialog(wx.Dialog):
         item = wx.MenuItem(menuPop, ID_AFFICHAGE_PERSPECTIVE_DEFAUT, _(u"Disposition par défaut"), _(u"Afficher la disposition par défaut"), wx.ITEM_CHECK)
         menuPop.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.On_affichage_perspective_defaut, id=ID_AFFICHAGE_PERSPECTIVE_DEFAUT)
-        if self.perspective_active == None : item.Check(True)
+        if self.perspective_active == None:
+            item.Check(True)
 
         index = 0
         for dictPerspective in self.perspectives:
             label = dictPerspective["label"]
             item = wx.MenuItem(menuPop, ID_PREMIERE_PERSPECTIVE + index, label, _(u"Afficher la disposition '%s'") % label, wx.ITEM_CHECK)
             menuPop.AppendItem(item)
-            if self.perspective_active == index : item.Check(True)
+            if self.perspective_active == index:
+                item.Check(True)
             index += 1
         self.Bind(wx.EVT_MENU_RANGE, self.On_affichage_perspective_perso, id=ID_PREMIERE_PERSPECTIVE, id2=ID_PREMIERE_PERSPECTIVE+99 )
 
@@ -760,23 +779,23 @@ class Dialog(wx.Dialog):
         menuPop.AppendSeparator()
 
         self.listePanneaux = [
-            { "label" : _(u"Sélection de la date"), "code" : "calendrier", "IDmenu" : None },
-            { "label" : _(u"Sélection des activités"), "code" : "activites", "IDmenu" : None },
-            { "label" : _(u"Légende"), "code" : "legende", "IDmenu" : None },
-            { "label" : _(u"Touches raccourcis"), "code" : "raccourcis", "IDmenu" : None },
-            { "label" : _(u"Totaux"), "code" : "totaux", "IDmenu" : None },
+            { "label": _(u"Sélection de la date"), "code": "calendrier", "IDmenu": None },
+            { "label": _(u"Sélection des activités"), "code": "activites", "IDmenu": None },
+            { "label": _(u"Légende"), "code": "legende", "IDmenu": None },
+            { "label": _(u"Touches raccourcis"), "code": "raccourcis", "IDmenu": None },
+            { "label": _(u"Totaux"), "code": "totaux", "IDmenu": None },
             ]
         ID = ID_AFFICHAGE_PANNEAUX
-        for dictPanneau in self.listePanneaux :
+        for dictPanneau in self.listePanneaux:
             dictPanneau["IDmenu"] = ID
             label = dictPanneau["label"]
             item = wx.MenuItem(menuPop, dictPanneau["IDmenu"], label, _(u"Afficher le panneau '%s'") % label, wx.ITEM_CHECK)
             menuPop.AppendItem(item)
             panneau = self._mgr.GetPane(dictPanneau["code"])
-            if panneau.IsShown() == True :
+            if panneau.IsShown() == True:
                 item.Check(True)
             ID += 1
-        self.Bind(wx.EVT_MENU_RANGE, self.On_affichage_panneau_afficher, id=ID_AFFICHAGE_PANNEAUX, id2=ID_AFFICHAGE_PANNEAUX+len(self.listePanneaux) )
+        self.Bind(wx.EVT_MENU_RANGE, self.On_affichage_panneau_afficher, id=ID_AFFICHAGE_PANNEAUX, id2=ID_AFFICHAGE_PANNEAUX+len(self.listePanneaux))
 
         menuPop.AppendSeparator()
 
@@ -863,20 +882,20 @@ class Dialog(wx.Dialog):
         dlg.Destroy()
 
         # Sauvegarde de la perspective
-        self.perspectives.append( {"label" : label, "perspective" : self._mgr.SavePerspective() } )
+        self.perspectives.append({"label": label, "perspective": self._mgr.SavePerspective()})
         self.perspective_active = newIDperspective
 
     def On_affichage_perspective_suppr(self, event):
         listeLabels = []
-        for dictPerspective in self.perspectives :
+        for dictPerspective in self.perspectives:
             listeLabels.append(dictPerspective["label"])
         dlg = wx.MultiChoiceDialog( self, _(u"Cochez les dispositions que vous souhaitez supprimer :"), _(u"Supprimer des dispositions"), listeLabels)
-        if dlg.ShowModal() == wx.ID_OK :
+        if dlg.ShowModal() == wx.ID_OK:
             selections = dlg.GetSelections()
             selections.sort(reverse=True)
-            for index in selections :
+            for index in selections:
                 self.perspectives.pop(index)
-            if self.perspective_active in selections :
+            if self.perspective_active in selections:
                 self._mgr.LoadPerspective(self.perspective_defaut)
             self.perspective_active = None
         dlg.Destroy()
@@ -884,7 +903,7 @@ class Dialog(wx.Dialog):
     def On_affichage_panneau_afficher(self, event):
         index = event.GetId() - ID_AFFICHAGE_PANNEAUX
         panneau = self._mgr.GetPane(self.listePanneaux[index]["code"])
-        if panneau.IsShown() :
+        if panneau.IsShown():
             panneau.Hide()
         else:
             panneau.Show()
@@ -898,15 +917,15 @@ class Dialog(wx.Dialog):
         reponse = dlg.ShowModal()
         if reponse == wx.ID_OK:
             newLargeur = dlg.GetValue()
-            try :
+            try:
                 newLargeur = int(newLargeur)
-            except :
+            except:
                 dlg2 = wx.MessageDialog(self, _(u"La valeur saisie semble incorrecte !"), _(u"Erreur de saisie"), wx.OK | wx.ICON_INFORMATION)
                 dlg2.ShowModal()
                 dlg2.Destroy()
                 dlg.Destroy()
                 return
-            if newLargeur < 30 or newLargeur > 300 :
+            if newLargeur < 30 or newLargeur > 300:
                 dlg2 = wx.MessageDialog(self, _(u"La valeur doit être comprise entre 30 et 300 !"), _(u"Erreur de saisie"), wx.OK | wx.ICON_INFORMATION)
                 dlg2.ShowModal()
                 dlg2.Destroy()
@@ -939,10 +958,14 @@ class Dialog(wx.Dialog):
         self.panel_grille.grille.MAJ_affichage()
 
     def On_format_label_ligne(self, event):
-        if event.GetId() == ID_FORMAT_LABEL_LIGNE_1 : self.panel_grille.grille.SetFormatLabelLigne("nom_prenom")
-        if event.GetId() == ID_FORMAT_LABEL_LIGNE_2 : self.panel_grille.grille.SetFormatLabelLigne("prenom_nom")
-        if event.GetId() == ID_FORMAT_LABEL_LIGNE_3 : self.panel_grille.grille.SetFormatLabelLigne("nom_prenom_id")
-        if event.GetId() == ID_FORMAT_LABEL_LIGNE_4 : self.panel_grille.grille.SetFormatLabelLigne("prenom_nom_id")
+        if event.GetId() == ID_FORMAT_LABEL_LIGNE_1:
+            self.panel_grille.grille.SetFormatLabelLigne("nom_prenom")
+        if event.GetId() == ID_FORMAT_LABEL_LIGNE_2:
+            self.panel_grille.grille.SetFormatLabelLigne("prenom_nom")
+        if event.GetId() == ID_FORMAT_LABEL_LIGNE_3:
+            self.panel_grille.grille.SetFormatLabelLigne("nom_prenom_id")
+        if event.GetId() == ID_FORMAT_LABEL_LIGNE_4:
+            self.panel_grille.grille.SetFormatLabelLigne("prenom_nom_id")
 
 
 if __name__ == "__main__":

--- a/noethys/Dlg/DLG_Gestionnaire_conso.py
+++ b/noethys/Dlg/DLG_Gestionnaire_conso.py
@@ -17,7 +17,7 @@ import datetime
 import time
 import wx.lib.agw.aui as aui
 import wx.html as html
-import wx.lib.agw.hyperlink as Hyperlink
+# import wx.lib.agw.hyperlink as Hyperlink
 
 from Utils import UTILS_Config
 from Utils import UTILS_Utilisateurs
@@ -66,7 +66,6 @@ ID_OUTILS_TOUT_SELECTIONNER = wx.NewId()
 ID_OUTILS_TOUT_DESELECTIONNER = wx.NewId()
 
 
-
 def DateComplete(dateDD):
     """ Transforme une date DD en date complète : Ex : lundi 15 janvier 2008 """
     listeJours = (_(u"Lundi"), _(u"Mardi"), _(u"Mercredi"), _(u"Jeudi"), _(u"Vendredi"), _(u"Samedi"), _(u"Dimanche"))
@@ -74,13 +73,16 @@ def DateComplete(dateDD):
     dateComplete = listeJours[dateDD.weekday()] + " " + str(dateDD.day) + " " + listeMois[dateDD.month-1] + " " + str(dateDD.year)
     return dateComplete
 
+
 def DateEngEnDateDD(dateEng):
     return datetime.date(int(dateEng[:4]), int(dateEng[5:7]), int(dateEng[8:10]))
+
 
 def CalculeAge(dateReference, date_naiss):
     # Calcul de l'age de la personne
     age = (dateReference.year - date_naiss.year) - int((dateReference.month, dateReference.day) < (date_naiss.month, date_naiss.day))
-    return age        
+    return age
+
 
 class CTRL_Titre(html.HtmlWindow):
     def __init__(self, parent, texte="", hauteur=30,  couleurFond=(255, 255, 255)):
@@ -90,14 +92,10 @@ class CTRL_Titre(html.HtmlWindow):
         self.SetBorders(4)
         self.SetMinSize((-1, hauteur))
         self.couleurFond = couleurFond
-            
+
     def SetTexte(self, texte=""):
         self.SetPage(u"<B><FONT SIZE=5 COLOR='WHITE'>%s</FONT></B>""" % texte)
         self.SetBackgroundColour(self.couleurFond)
-
-
-
-
 
 
 class Commandes(wx.Panel):
@@ -105,7 +103,7 @@ class Commandes(wx.Panel):
         """ Boutons de commande en bas de la fenêtre """
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
-        # Boutons 
+        # Boutons
         self.bouton_aide = CTRL_Bouton_image.CTRL(self, texte=_(u"Aide"), cheminImage="Images/32x32/Aide.png")
         self.bouton_options = CTRL_Bouton_image.CTRL(self, texte=_(u"Options"), cheminImage="Images/32x32/Configuration2.png")
         self.bouton_outils = self.bouton_ok = CTRL_Bouton_image.CTRL(self, texte=_(u"Outils"), cheminImage="Images/32x32/Configuration.png")
@@ -116,7 +114,7 @@ class Commandes(wx.Panel):
         self.bouton_options.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour définir les paramètres d'affichage de la fenêtre")))
         self.bouton_outils.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour accéder aux outils")))
         self.bouton_annuler.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour fermer")))
-        
+
         # Layout
         sizer_base = wx.BoxSizer(wx.VERTICAL)
         grid_sizer_base = wx.FlexGridSizer(rows=1, cols=7, vgap=10, hgap=10)
@@ -145,16 +143,16 @@ class Commandes(wx.Panel):
         self.parent.MemoriseParametres()
         # Fermeture de la fenêtre
         self.parent.EndModal(wx.ID_OK)
-        
+
     def OnBoutonAide(self, event):
         from Utils import UTILS_Aide
         UTILS_Aide.Aide("Gestionnairedesconsommations")
-    
+
     def OnBoutonOutils(self, event):
         self.parent.MenuOutils()
-    
+
     def OnBoutonAnnuler(self, event):
-        etat = self.parent.Annuler() 
+        etat = self.parent.Annuler()
         if etat == False :
             return
         self.parent.EndModal(wx.ID_CANCEL)
@@ -177,8 +175,8 @@ class Commandes(wx.Panel):
 ##        self.UpdateLink()
 ##        self.DoPopup(False)
 ##        self.Bind(Hyperlink.EVT_HYPERLINK_LEFT, self.OnLeftLink)
-##    
-##    def OnLeftLink(self, event):        
+##
+##    def OnLeftLink(self, event):
 ##        if self.URL == "AJOUTER" :
 ##            import DLG_Grille_ajouter_individu
 ##            dlg = DLG_Grille_ajouter_individu.Dialog(self)
@@ -195,15 +193,15 @@ class Commandes(wx.Panel):
 ##
 ##        if self.URL == "INSCRITS" :
 ##            self.GetGrandParent().AfficherTousInscrits()
-##        
+##
 ##        self.UpdateLink()
-        
+
 
 ##class CTRL_Options(wx.Panel):
 ##    def __init__(self, parent):
 ##        wx.Panel.__init__(self, parent, -1)
 ##        self.parent = parent
-##        
+##
 ##        # Ajouter individu
 ##        self.hyper_ajouter_individu = Hyperlien(self, label=_(u"Ajouter un individu"), infobulle=_(u"Cliquez ici pour ajouter un individu à la liste afichée"), URL="AJOUTER")
 ##        self.label_separation_1 = wx.StaticText(self, -1, u"|")
@@ -214,11 +212,11 @@ class Commandes(wx.Panel):
 ##        self.radio_attente = wx.RadioButton(self, -1, _(u"Attente") )
 ##        self.radio_refus = wx.RadioButton(self, -1, _(u"Refus") )
 ##        self.radio_reservation.SetValue(True)
-##        
+##
 ##        self.radio_reservation.SetToolTip(wx.ToolTip(_(u"Le mode Réservation permet de saisir une réservation")))
 ##        self.radio_attente.SetToolTip(wx.ToolTip(_(u"Le mode Attente permet de saisir une place sur liste d'attente")))
 ##        self.radio_refus.SetToolTip(wx.ToolTip(_(u"Le mode de refus permet de saisir une place sur liste d'attente qui a été refusée par l'individu. Cette saisie est juste utilisée à titre statistique")))
-##        
+##
 ##        grid_sizer_base = wx.FlexGridSizer(rows=1, cols=8, vgap=5, hgap=5)
 ##        grid_sizer_base.Add(self.hyper_ajouter_individu, 0, wx.EXPAND, 0)
 ##        grid_sizer_base.Add(self.label_separation_1, 0, 0, 0)
@@ -235,10 +233,10 @@ class Commandes(wx.Panel):
 ##        self.Bind(wx.EVT_RADIOBUTTON, self.OnRadioMode, self.radio_reservation)
 ##        self.Bind(wx.EVT_RADIOBUTTON, self.OnRadioMode, self.radio_attente)
 ##        self.Bind(wx.EVT_RADIOBUTTON, self.OnRadioMode, self.radio_refus)
-##    
+##
 ##    def OnRadioMode(self, event):
 ##        pass
-##    
+##
 ##    def GetMode(self):
 ##        if self.radio_reservation.GetValue() == True : return "reservation"
 ##        if self.radio_attente.GetValue() == True : return "attente"
@@ -254,18 +252,18 @@ class PanelGrille(wx.Panel):
         self.listeActivites = []
         self.listeGroupes = []
         self.dictIndividusAjoutes = {}
-        
+
         # Paramètres de sélection
         self.listeSelectionActivites = [] #[1,]
         self.listeSelectionIndividus =  [] #[24,]
-        
+
         # Création des contrôles
         self.ctrl_titre = CTRL_Titre(self, couleurFond="#316AC5")
         self.grille = CTRL_Grille.CTRL(self, "date")
-        
+
         # Barre d'outils
-        self.barreOutils = wx.ToolBar(self, -1, style = 
-            wx.TB_HORIZONTAL 
+        self.barreOutils = wx.ToolBar(self, -1, style =
+            wx.TB_HORIZONTAL
             | wx.NO_BORDER
             | wx.TB_FLAT
             | wx.TB_TEXT
@@ -274,7 +272,7 @@ class PanelGrille(wx.Panel):
             )
         self.ctrl_recherche = CTRL_Grille.BarreRecherche(self.barreOutils, ctrl_grille=self.grille)
         self.barreOutils.AddControl(self.ctrl_recherche)
-        
+
         self.barreOutils.AddLabelTool(ID_AJOUTER_INDIVIDU, label=_(u"Ajouter un individu"), bitmap=wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Femme.png"), wx.BITMAP_TYPE_PNG), shortHelp=_(u"Ajouter un individu"), longHelp=_(u"Ajouter un individu"))
         self.barreOutils.AddLabelTool(ID_AFFICHER_TOUS_INSCRITS, label=_(u"Afficher tous les inscrits"), bitmap=wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Famille.png"), wx.BITMAP_TYPE_PNG), shortHelp=_(u"Afficher tous les inscrits"), longHelp=_(u"Afficher tous les inscrits"))
         try :
@@ -298,16 +296,16 @@ class PanelGrille(wx.Panel):
         grid_sizer_base.AddGrowableRow(1)
         self.SetSizer(grid_sizer_base)
         self.Layout()
-    
+
     def Reinitialisation_grille(self):
         """ A utiliser après une sauvegarde de la grille """
-        self.grille.InitDonnees() 
-        self.MAJ_grille() 
-        
+        self.grille.InitDonnees()
+        self.MAJ_grille()
+
     def MAJ_grille(self):
         self.listeSelectionIndividus = self.GetListeIndividus()
         self.grille.SetModeDate(self.listeActivites, self.listeSelectionIndividus, self.date)
-            
+
     def SetDate(self, date=None):
         self.date = date
         if self.date == None :
@@ -315,13 +313,13 @@ class PanelGrille(wx.Panel):
         else:
             dateStr = DateComplete(self.date)
         self.ctrl_titre.SetTexte(dateStr)
-    
+
     def SetActivites(self, listeActivites=[]):
         self.listeActivites = listeActivites
-    
+
     def SetGroupes(self, listeGroupes=[]):
         self.listeGroupes = listeGroupes
-    
+
     def GetListeIndividus(self):
         listeSelectionIndividus = []
         # Conditions Activités :
@@ -332,7 +330,7 @@ class PanelGrille(wx.Panel):
         if len(self.listeGroupes) == 0 : conditionGroupes = ""
         elif len(self.listeGroupes) == 1 : conditionGroupes = " AND IDgroupe=%d" % self.listeGroupes[0]
         else : conditionGroupes = " AND IDgroupe IN %s" % str(tuple(self.listeGroupes))
-        
+
         DB = GestionDB.DB()
         req = """SELECT IDindividu, COUNT(IDconso)
         FROM consommations
@@ -340,11 +338,11 @@ class PanelGrille(wx.Panel):
         GROUP BY IDindividu
         ORDER BY IDindividu;""" % (str(self.date), conditionActivites, conditionGroupes)
         DB.ExecuterReq(req)
-        listeDonnees = DB.ResultatReq()      
-        DB.Close() 
+        listeDonnees = DB.ResultatReq()
+        DB.Close()
         for IDindividu, nbreConsommations in listeDonnees :
             listeSelectionIndividus.append(IDindividu)
-        
+
         # On ajoute les individus ajoutés manuellement :
         if self.dictIndividusAjoutes.has_key(self.date) :
             for IDindividu in self.dictIndividusAjoutes[self.date] :
@@ -356,9 +354,9 @@ class PanelGrille(wx.Panel):
                             for conso in listeConso :
                                 if conso.IDgroupe in self.listeGroupes :
                                     valide = True
-                if valide == True and IDindividu not in listeSelectionIndividus : 
+                if valide == True and IDindividu not in listeSelectionIndividus :
                     listeSelectionIndividus.append(IDindividu)
-        
+
         return listeSelectionIndividus
 
     def AjouterIndividu(self, event=None):
@@ -401,10 +399,9 @@ class PanelGrille(wx.Panel):
         GROUP BY IDindividu
         ORDER BY IDindividu;""" % (conditionActivites, conditionGroupes, self.date)
         DB.ExecuterReq(req)
-        listeDonnees = DB.ResultatReq()      
-        DB.Close() 
-        
-        listeIndividus = []
+        listeDonnees = DB.ResultatReq()
+        DB.Close()
+
         for IDinscription, IDindividu in listeDonnees :
             if IDindividu not in self.listeSelectionIndividus :
                 self.listeSelectionIndividus.append(IDindividu)
@@ -415,16 +412,13 @@ class PanelGrille(wx.Panel):
                     self.dictIndividusAjoutes[self.date].append(IDindividu)
         # MAJ de l'affichage
         self.grille.SetModeDate(self.listeActivites, self.listeSelectionIndividus, self.date)
-        
+
     def GetMode(self):
         if self.barreOutils.GetToolState(ID_MODE_RESERVATION) == True : return "reservation"
         if self.barreOutils.GetToolState(ID_MODE_ATTENTE) == True : return "attente"
         if self.barreOutils.GetToolState(ID_MODE_REFUS) == True : return "refus"
 
 
-
-
-        
 class Dialog(wx.Dialog):
     def __init__(self, parent):
         wx.Dialog.__init__(self, parent, -1, name="DLG_Gestionnaire_conso", style=wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER|wx.MAXIMIZE_BOX|wx.MINIMIZE_BOX)
@@ -432,7 +426,7 @@ class Dialog(wx.Dialog):
 
         self._mgr = aui.AuiManager()
         self._mgr.SetManagedWindow(self)
-        
+
         # Détermine la taille de la fenêtre
         self.SetMinSize((700, 600))
         taille_fenetre = UTILS_Config.GetParametre("taille_fenetre_tableau_presences")
@@ -462,7 +456,7 @@ class Dialog(wx.Dialog):
         self.dictIndividus = self.panel_grille.grille.dictIndividus
         self.dictGroupes = self.panel_grille.grille.dictGroupes
         self.listeSelectionIndividus = self.panel_grille.grille.listeSelectionIndividus
-                        
+
         # Création des panels amovibles
         self.panel_commandes = Commandes(self)
         self._mgr.AddPane(self.panel_commandes, aui.AuiPaneInfo().
@@ -478,14 +472,14 @@ class Dialog(wx.Dialog):
         self._mgr.AddPane(self.panel_calendrier, aui.AuiPaneInfo().
                           Name("calendrier").Caption(_(u"Sélection de la date")).
                           Left().Layer(1).BestSize(wx.Size(195, 180)).Position(1).CloseButton(False).Fixed().MaximizeButton(False))
-                                
-        self.panel_activites = CTRL_Grille_activite3.CTRL(self)        
+
+        self.panel_activites = CTRL_Grille_activite3.CTRL(self)
         self._mgr.AddPane(self.panel_activites, aui.AuiPaneInfo().
                           Name("activites").Caption(_(u"Sélection des activités")).
                           Left().Layer(1).Position(1).CloseButton(False).MaximizeButton(False).BestSize(wx.Size(-1,50)))
         pi = self._mgr.GetPane("activites")
         pi.dock_proportion = 100000 # Proportion
-        
+
         self.panel_legende = OL_Legende_grille.ListView(self, id=-1, name="OL_legende", style=wx.LC_REPORT|wx.LC_NO_HEADER | wx.SUNKEN_BORDER|wx.LC_SINGLE_SEL)
         self.panel_legende.SetSize((50, 50))
         self._mgr.AddPane(self.panel_legende, aui.AuiPaneInfo().
@@ -502,7 +496,7 @@ class Dialog(wx.Dialog):
         self.panel_etiquettes = CTRL_Etiquettes.CTRL(self, activeMenu=False)
         self._mgr.AddPane(self.panel_etiquettes, aui.AuiPaneInfo().
                           Name("etiquettes").Caption(_(u"Etiquettes")).
-                          Right().Layer(0).Position(0).CloseButton(False).BestSize(wx.Size(275, 100)).MaximizeButton(False).MinSize((275, 100)))    
+                          Right().Layer(0).Position(0).CloseButton(False).BestSize(wx.Size(275, 100)).MaximizeButton(False).MinSize((275, 100)))
         self._mgr.GetPane("etiquettes").Hide()
 
         self.panel_forfaits = CTRL_Grille_forfaits.CTRL(self, grille=self.panel_grille.grille)
@@ -510,12 +504,12 @@ class Dialog(wx.Dialog):
                           Name("forfaits").Caption(_(u"Forfaits crédits")).
                           Right().Layer(0).Position(1).BestSize(wx.Size(275,140)).Position(4).CloseButton(False).MaximizeButton(False).MinSize((275, 100)))
         self._mgr.GetPane("forfaits").Hide()
-        
+
         # Création du panel central
         self._mgr.AddPane(self.panel_grille, aui.AuiPaneInfo().Name("grille").
                           CenterPane())
-        self._mgr.GetPane("grille").Show()     
-        
+        self._mgr.GetPane("grille").Show()
+
         # Sauvegarde de la perspective par défaut
         self.perspective_defaut = self._mgr.SavePerspective()
 
@@ -524,7 +518,7 @@ class Dialog(wx.Dialog):
             self._mgr.LoadPerspective(self.perspectives[self.perspective_active]["perspective"])
         else:
             self._mgr.LoadPerspective(self.perspective_defaut)
-        
+
         # Affichage du panneau du panneau Forfait Credits
         if self.panel_grille.grille.tarifsForfaitsCreditsPresents == True :
             self._mgr.GetPane("forfaits").Show()
@@ -538,41 +532,40 @@ class Dialog(wx.Dialog):
             self._mgr.GetPane("etiquettes").Hide()
 
         self._mgr.Update()
-        
+
         self.SetTitle(_(u"Gestionnaire des consommations"))
-        
+
         self.Bind(wx.EVT_CLOSE, self.OnClose)
-                
+
         # Initialisation des contrôles
-        date = self.panel_calendrier.GetDate()
-##        self.SetDate(date)
-        
+#        date = self.panel_calendrier.GetDate()
+#        self.SetDate(date)
+
         # Init
         self.panel_activites.SetCocherParDefaut(UTILS_Config.GetParametre("gestionnaire_conso_cocher_activites", defaut=True))
 
         # Affichage du panneau du panneau Forfait Credits
-##        if self.panel_grille.grille.tarifsForfaitsCreditsPresents == True :
-##            self._mgr.GetPane("forfaits").Show()
-##        else:
-##            self._mgr.GetPane("forfaits").Hide()
-##        self._mgr.Update()
+#        if self.panel_grille.grille.tarifsForfaitsCreditsPresents == True :
+#            self._mgr.GetPane("forfaits").Show()
+#        else:
+#            self._mgr.GetPane("forfaits").Hide()
+#        self._mgr.Update()
 
         # Contre le bug de maximize
         wx.CallAfter(self._mgr.Update)
-
 
     def AffichePanneauForfaitsCredit(self):
         self._mgr.GetPane("forfaits").Show()
 
     def MAJ_totaux(self):
-        self.panel_totaux.MAJ() 
+        self.panel_totaux.MAJ()
 
     def MAJ_totaux_contenu(self):
         self.panel_totaux.MAJ_donnees()
-        self.panel_totaux.MAJ_contenu() 
-    
+        self.panel_totaux.MAJ_contenu()
+
     def SetDate(self, date):
-##        heure_debut = time.time()
+#        heure_debut = time.time()
         self.panel_activites.SetDate(date)
         self.panel_grille.SetDate(date)
         listeActivites, listeGroupes = self.panel_activites.GetActivitesEtGroupes()
@@ -581,15 +574,15 @@ class Dialog(wx.Dialog):
         self.panel_grille.SetGroupes(listeGroupes)
         self.panel_grille.MAJ_grille()
         self.panel_totaux.MAJ(date)
-##        print "Temps de chargement =", time.time() - heure_debut
-    
+#        print "Temps de chargement =", time.time() - heure_debut
+
     def GetDate(self):
         return self.panel_calendrier.GetDate()
-    
-##    def SetActivites(self, listeActivites=[]):
-##        self.panel_grille.SetActivites(self.panel_activites.GetListeActivites())
-##        self.panel_grille.MAJ_grille()
-##        self.panel_totaux.MAJ()
+
+#    def SetActivites(self, listeActivites=[]):
+#        self.panel_grille.SetActivites(self.panel_activites.GetListeActivites())
+#        self.panel_grille.MAJ_grille()
+#        self.panel_totaux.MAJ()
 
     def MAJactivites(self):
         listeActivites, listeGroupes = self.panel_activites.GetActivitesEtGroupes()
@@ -598,19 +591,19 @@ class Dialog(wx.Dialog):
         self.panel_grille.SetGroupes(listeGroupes)
         self.panel_grille.MAJ_grille()
         self.panel_totaux.MAJ()
-        
+
     def MAJ_grille(self):
         self.panel_grille.MAJ_grille()
         self.panel_totaux.MAJ()
-    
+
     def OnClose(self, event):
         self.MemoriseParametres()
-        etat = self.Annuler() 
+        etat = self.Annuler()
         if etat == False :
             return
-        event.Skip() 
-        
-    def MemoriseParametres(self):        
+        event.Skip()
+
+    def MemoriseParametres(self):
         # Mémorisation du paramètre de la taille d'écran
         if self.IsMaximized() == True :
             taille_fenetre = (0, 0)
@@ -621,13 +614,13 @@ class Dialog(wx.Dialog):
         UTILS_Config.SetParametre("gestionnaire_perspectives", self.perspectives)
         UTILS_Config.SetParametre("gestionnaire_perspective_active", self.perspective_active)
         # Paramètres grille
-        self.panel_grille.grille.MemoriseParametres() 
+        self.panel_grille.grille.MemoriseParametres()
 
     def Annuler(self):
         if len(self.panel_grille.grille.listeHistorique) > 0 :
-##            texteHistorique = self.panel_grille.grille.GetTexteHistorique() 
+#            texteHistorique = self.panel_grille.grille.GetTexteHistorique()
             dlg = wx.MessageDialog(self, _(u"Des modifications ont été effectuées dans la grille.\n\nSouhaitez-vous enregistrer ces modifications avant de fermer cette fenêtre ?"), _(u"Sauvegarde des modifications"), wx.YES_NO|wx.YES_DEFAULT|wx.CANCEL|wx.ICON_EXCLAMATION)
-            reponse = dlg.ShowModal() 
+            reponse = dlg.ShowModal()
             dlg.Destroy()
             if reponse == wx.ID_CANCEL :
                 return False
@@ -635,17 +628,17 @@ class Dialog(wx.Dialog):
                 # Sauvegarde des données
                 self.panel_grille.grille.Sauvegarde()
             return True
-    
+
     def MenuOutils(self):
         # Création du menu Outils
         menuPop = wx.Menu()
-            
-##        item = wx.MenuItem(menuPop, ID_OUTILS_SAISIE_FORFAIT, _(u"Appliquer un forfait daté"), _(u"Appliquer un forfait daté"))
-##        item.SetBitmap(wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Forfait.png"), wx.BITMAP_TYPE_PNG))
-##        menuPop.AppendItem(item)
-##        self.Bind(wx.EVT_MENU, self.On_outils_saisie_forfait, id=ID_OUTILS_SAISIE_FORFAIT)
-##        
-##        menuPop.AppendSeparator()
+
+#        item = wx.MenuItem(menuPop, ID_OUTILS_SAISIE_FORFAIT, _(u"Appliquer un forfait daté"), _(u"Appliquer un forfait daté"))
+#        item.SetBitmap(wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Forfait.png"), wx.BITMAP_TYPE_PNG))
+#        menuPop.AppendItem(item)
+#        self.Bind(wx.EVT_MENU, self.On_outils_saisie_forfait, id=ID_OUTILS_SAISIE_FORFAIT)
+#
+#        menuPop.AppendSeparator()
 
         item = wx.MenuItem(menuPop, ID_OUTILS_IMPRIMER_CONSO, _(u"Imprimer la liste des consommations"), _(u"Imprimer la liste des consommations"))
         item.SetBitmap(wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Imprimante.png"), wx.BITMAP_TYPE_PNG))
@@ -685,7 +678,7 @@ class Dialog(wx.Dialog):
 
         self.PopupMenu(menuPop)
         menuPop.Destroy()
-        
+
     # def On_outils_convert_etat(self, event):
     #     """ Convertit tous les refus en réservations """
     #     if UTILS_Utilisateurs.VerificationDroitsUtilisateurActuel("consommations_conso", "modifier") == False : return
@@ -703,46 +696,46 @@ class Dialog(wx.Dialog):
     #         return
     #     self.panel_grille.grille.ConvertirEtat(etatInitial=codeEtat1, etatFinal=codeEtat2)
 
-        
+
     def On_outils_imprimer(self, event):
         if len(self.panel_grille.grille.listeHistorique) > 0 :
-##            texteHistorique = self.panel_grille.grille.GetTexteHistorique() 
+##            texteHistorique = self.panel_grille.grille.GetTexteHistorique()
             dlg = wx.MessageDialog(self, _(u"Des modifications ont été effectuées dans la grille.\n\nSouhaitez-vous les enregistrer maintenant afin qu'elles apparaissent dans le document ?"), _(u"Sauvegarde des modifications"), wx.YES_NO|wx.YES_DEFAULT|wx.CANCEL|wx.ICON_EXCLAMATION)
-            reponse = dlg.ShowModal() 
+            reponse = dlg.ShowModal()
             dlg.Destroy()
             if reponse != wx.ID_YES :
-                return 
-            
+                return
+
             # Sauvegarde des données
             self.panel_grille.grille.Sauvegarde()
             # Re-initialisation de la grille
             self.panel_grille.Reinitialisation_grille()
-            
+
         # Impression PDF
-        date = self.GetDate() 
+        date = self.GetDate()
         import DLG_Impression_conso
         dlg = DLG_Impression_conso.Dialog(self, date=date)
-        dlg.ShowModal() 
+        dlg.ShowModal()
         dlg.Destroy()
 
     def On_outils_recalculer(self, event):
         if UTILS_Utilisateurs.VerificationDroitsUtilisateurActuel("consommations_conso", "modifier") == False : return
         dlg = wx.MessageDialog(self, _(u"Confirmez-vous le recalcul des prestations de toutes les consommations affichées ?"), _(u"Recalcul des prestations"), wx.YES_NO|wx.NO_DEFAULT|wx.CANCEL|wx.ICON_QUESTION)
-        reponse = dlg.ShowModal() 
+        reponse = dlg.ShowModal()
         dlg.Destroy()
         if reponse != wx.ID_YES :
-            return 
-        self.panel_grille.grille.RecalculerToutesPrestations() 
+            return
+        self.panel_grille.grille.RecalculerToutesPrestations()
 
     def MenuOptions(self):
         # Création du menu Options
         menuPop = wx.Menu()
-    
+
         item = wx.MenuItem(menuPop, ID_AFFICHAGE_PERSPECTIVE_DEFAUT, _(u"Disposition par défaut"), _(u"Afficher la disposition par défaut"), wx.ITEM_CHECK)
         menuPop.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.On_affichage_perspective_defaut, id=ID_AFFICHAGE_PERSPECTIVE_DEFAUT)
         if self.perspective_active == None : item.Check(True)
-        
+
         index = 0
         for dictPerspective in self.perspectives:
             label = dictPerspective["label"]
@@ -751,24 +744,24 @@ class Dialog(wx.Dialog):
             if self.perspective_active == index : item.Check(True)
             index += 1
         self.Bind(wx.EVT_MENU_RANGE, self.On_affichage_perspective_perso, id=ID_PREMIERE_PERSPECTIVE, id2=ID_PREMIERE_PERSPECTIVE+99 )
-        
+
         menuPop.AppendSeparator()
-        
+
         item = wx.MenuItem(menuPop, ID_AFFICHAGE_PERSPECTIVE_SAVE, _(u"Sauvegarder la disposition actuelle"), _(u"Sauvegarder la disposition actuelle de la page d'accueil"))
         item.SetBitmap(wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Perspective_ajouter.png"), wx.BITMAP_TYPE_PNG))
         menuPop.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.On_affichage_perspective_save, id=ID_AFFICHAGE_PERSPECTIVE_SAVE)
-        
+
         item = wx.MenuItem(menuPop, ID_AFFICHAGE_PERSPECTIVE_SUPPR, _(u"Supprimer des dispositions"), _(u"Supprimer des dispositions de page d'accueil sauvegardée"))
         item.SetBitmap(wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Perspective_supprimer.png"), wx.BITMAP_TYPE_PNG))
         menuPop.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.On_affichage_perspective_suppr, id=ID_AFFICHAGE_PERSPECTIVE_SUPPR)
-        
+
         menuPop.AppendSeparator()
-        
+
         self.listePanneaux = [
             { "label" : _(u"Sélection de la date"), "code" : "calendrier", "IDmenu" : None },
-            { "label" : _(u"Sélection des activités"), "code" : "activites", "IDmenu" : None }, 
+            { "label" : _(u"Sélection des activités"), "code" : "activites", "IDmenu" : None },
             { "label" : _(u"Légende"), "code" : "legende", "IDmenu" : None },
             { "label" : _(u"Touches raccourcis"), "code" : "raccourcis", "IDmenu" : None },
             { "label" : _(u"Totaux"), "code" : "totaux", "IDmenu" : None },
@@ -784,11 +777,11 @@ class Dialog(wx.Dialog):
                 item.Check(True)
             ID += 1
         self.Bind(wx.EVT_MENU_RANGE, self.On_affichage_panneau_afficher, id=ID_AFFICHAGE_PANNEAUX, id2=ID_AFFICHAGE_PANNEAUX+len(self.listePanneaux) )
-        
+
         menuPop.AppendSeparator()
-        
+
         sousMenuLabelLigne = wx.Menu()
-            
+
         item = wx.MenuItem(sousMenuLabelLigne, ID_FORMAT_LABEL_LIGNE_1, _(u"Nom Prénom"), _(u"Format du label : 'Nom Prénom'"), wx.ITEM_RADIO)
         sousMenuLabelLigne.AppendItem(item)
         item.Check(self.panel_grille.grille.GetFormatLabelLigne() == "nom_prenom")
@@ -808,10 +801,9 @@ class Dialog(wx.Dialog):
         sousMenuLabelLigne.AppendItem(item)
         item.Check(self.panel_grille.grille.GetFormatLabelLigne() == "prenom_nom_id")
         self.Bind(wx.EVT_MENU, self.On_format_label_ligne, id=ID_FORMAT_LABEL_LIGNE_4)
-        
+
         item = menuPop.AppendMenu(ID_FORMAT_LABEL_LIGNE_MENU, _(u"Format du label de la ligne"), sousMenuLabelLigne)
 
-        
         menuPop.AppendSeparator()
 
         item = wx.MenuItem(menuPop, ID_AFFICHE_COLONNE_MEMO, _(u"Afficher la colonne Mémo journalier"), _(u"Afficher la colonne Mémo journalier"), wx.ITEM_CHECK)
@@ -823,7 +815,7 @@ class Dialog(wx.Dialog):
         menuPop.AppendItem(item)
         item.Check(self.panel_grille.grille.GetAfficheColonneTransports())
         self.Bind(wx.EVT_MENU, self.On_affiche_transports, id=ID_AFFICHE_COLONNE_TRANSPORTS)
-        
+
         item = wx.MenuItem(menuPop, ID_AFFICHAGE_PARAMETRES, _(u"Définir hauteur et largeurs des cases"), _(u"Définir la hauteur des lignes et la largeur des cases"))
         item.SetBitmap(wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Mecanisme.png"), wx.BITMAP_TYPE_PNG))
         menuPop.AppendItem(item)
@@ -848,7 +840,7 @@ class Dialog(wx.Dialog):
 
         self.PopupMenu(menuPop)
         menuPop.Destroy()
-    
+
     def On_affichage_perspective_defaut(self, event):
         self._mgr.LoadPerspective(self.perspective_defaut)
         self.perspective_active = None
@@ -864,17 +856,16 @@ class Dialog(wx.Dialog):
         dlg.SetValue(_(u"Disposition %d") % (newIDperspective + 1))
         reponse = dlg.ShowModal()
         if reponse != wx.ID_OK:
-            dlg.Destroy() 
+            dlg.Destroy()
             return
-        
+
         label = dlg.GetValue()
-        dlg.Destroy() 
-        
+        dlg.Destroy()
+
         # Sauvegarde de la perspective
         self.perspectives.append( {"label" : label, "perspective" : self._mgr.SavePerspective() } )
         self.perspective_active = newIDperspective
-            
-        
+
     def On_affichage_perspective_suppr(self, event):
         listeLabels = []
         for dictPerspective in self.perspectives :
@@ -889,7 +880,7 @@ class Dialog(wx.Dialog):
                 self._mgr.LoadPerspective(self.perspective_defaut)
             self.perspective_active = None
         dlg.Destroy()
-        
+
     def On_affichage_panneau_afficher(self, event):
         index = event.GetId() - ID_AFFICHAGE_PANNEAUX
         panneau = self._mgr.GetPane(self.listePanneaux[index]["code"])
@@ -898,7 +889,7 @@ class Dialog(wx.Dialog):
         else:
             panneau.Show()
         self._mgr.Update()
-    
+
     def On_affichage_largeur_unite(self, event):
         """ Définit la largeur de la colonne unité """
         largeur = self.panel_grille.grille.GetLargeurColonneUnite()
@@ -913,7 +904,7 @@ class Dialog(wx.Dialog):
                 dlg2 = wx.MessageDialog(self, _(u"La valeur saisie semble incorrecte !"), _(u"Erreur de saisie"), wx.OK | wx.ICON_INFORMATION)
                 dlg2.ShowModal()
                 dlg2.Destroy()
-                dlg.Destroy() 
+                dlg.Destroy()
                 return
             if newLargeur < 30 or newLargeur > 300 :
                 dlg2 = wx.MessageDialog(self, _(u"La valeur doit être comprise entre 30 et 300 !"), _(u"Erreur de saisie"), wx.OK | wx.ICON_INFORMATION)
@@ -921,12 +912,12 @@ class Dialog(wx.Dialog):
                 dlg2.Destroy()
                 return
             self.panel_grille.grille.SetLargeurColonneUnite(newLargeur)
-        dlg.Destroy() 
+        dlg.Destroy()
         UTILS_Config.SetParametre("largeur_colonne_unite", newLargeur)
 
     def On_affichage_parametres(self, event):
         """ Définit la largeur de la colonne unité """
-        self.panel_grille.grille.Parametres() 
+        self.panel_grille.grille.Parametres()
 
     def On_affiche_memo(self, event):
         grille = self.panel_grille.grille
@@ -935,18 +926,18 @@ class Dialog(wx.Dialog):
     def On_affiche_transports(self, event):
         grille = self.panel_grille.grille
         grille.SetAfficheColonneTransports(not grille.GetAfficheColonneTransports())
-    
+
     def On_cocher_activites_defaut(self, event):
         self.panel_activites.cocherParDefaut = not self.panel_activites.cocherParDefaut
         UTILS_Config.SetParametre("gestionnaire_conso_cocher_activites", self.panel_activites.cocherParDefaut)
-        
+
     def On_blocage_si_complet(self, event):
         self.panel_grille.grille.blocageSiComplet = not self.panel_grille.grille.blocageSiComplet
 
     def On_affiche_sans_prestation(self, event):
         self.panel_grille.grille.afficheSansPrestation = not self.panel_grille.grille.afficheSansPrestation
-        self.panel_grille.grille.MAJ_affichage() 
-    
+        self.panel_grille.grille.MAJ_affichage()
+
     def On_format_label_ligne(self, event):
         if event.GetId() == ID_FORMAT_LABEL_LIGNE_1 : self.panel_grille.grille.SetFormatLabelLigne("nom_prenom")
         if event.GetId() == ID_FORMAT_LABEL_LIGNE_2 : self.panel_grille.grille.SetFormatLabelLigne("prenom_nom")
@@ -954,13 +945,11 @@ class Dialog(wx.Dialog):
         if event.GetId() == ID_FORMAT_LABEL_LIGNE_4 : self.panel_grille.grille.SetFormatLabelLigne("prenom_nom_id")
 
 
-        
-
 if __name__ == "__main__":
     app = wx.App(0)
     heure_debut = time.time()
     dlg = Dialog(None)
-    print "Temps de chargement =", time.time() - heure_debut
+    print("Temps de chargement = {0}".format(time.time() - heure_debut))
     app.SetTopWindow(dlg)
     dlg.ShowModal()
-    app.MainLoop()    
+    app.MainLoop()

--- a/noethys/Dlg/DLG_Gestionnaire_conso.py
+++ b/noethys/Dlg/DLG_Gestionnaire_conso.py
@@ -68,14 +68,26 @@ ID_OUTILS_TOUT_DESELECTIONNER = wx.NewId()
 
 def DateComplete(dateDD):
     """ Transforme une date DD en date complète : Ex : lundi 15 janvier 2008 """
-    listeJours = (_(u"Lundi"), _(u"Mardi"), _(u"Mercredi"), _(u"Jeudi"), _(u"Vendredi"), _(u"Samedi"), _(u"Dimanche"))
-    listeMois = (_(u"janvier"), _(u"février"), _(u"mars"), _(u"avril"), _(u"mai"), _(u"juin"), _(u"juillet"), _(u"août"), _(u"septembre"), _(u"octobre"), _(u"novembre"), _(u"décembre"))
-    dateComplete = listeJours[dateDD.weekday()] + " " + str(dateDD.day) + " " + listeMois[dateDD.month-1] + " " + str(dateDD.year)
+    listeJours = (
+        _(u"Lundi"), _(u"Mardi"), _(u"Mercredi"), _(u"Jeudi"),
+        _(u"Vendredi"), _(u"Samedi"), _(u"Dimanche"),
+    )
+    listeMois = (
+        _(u"janvier"), _(u"février"), _(u"mars"), _(u"avril"), _(u"mai"),
+        _(u"juin"), _(u"juillet"), _(u"août"), _(u"septembre"),
+        _(u"octobre"), _(u"novembre"), _(u"décembre"),
+    )
+    dateComplete = "{0} {1} {2} {3}".format(
+        listeJours[dateDD.weekday()], str(dateDD.day),
+        listeMois[dateDD.month-1], str(dateDD.year),
+    )
     return dateComplete
 
 
 def DateEngEnDateDD(dateEng):
-    return datetime.date(int(dateEng[:4]), int(dateEng[5:7]), int(dateEng[8:10]))
+    return datetime.date(
+        int(dateEng[:4]), int(dateEng[5:7]), int(dateEng[8:10]),
+    )
 
 
 def CalculeAge(dateReference, date_naiss):
@@ -86,7 +98,11 @@ def CalculeAge(dateReference, date_naiss):
 
 class CTRL_Titre(html.HtmlWindow):
     def __init__(self, parent, texte="", hauteur=30,  couleurFond=(255, 255, 255)):
-        html.HtmlWindow.__init__(self, parent, -1, style=wx.html.HW_NO_SELECTION | wx.html.HW_SCROLLBAR_NEVER | wx.NO_FULL_REPAINT_ON_RESIZE)
+        html.HtmlWindow.__init__(self, parent, -1, style=(
+            wx.html.HW_NO_SELECTION |
+            wx.html.HW_SCROLLBAR_NEVER |
+            wx.NO_FULL_REPAINT_ON_RESIZE
+        ))
         if "gtk2" in wx.PlatformInfo:
             self.SetStandardFonts()
         self.SetBorders(4)
@@ -110,10 +126,18 @@ class Commandes(wx.Panel):
         self.bouton_ok = CTRL_Bouton_image.CTRL(self, texte=_(u"Ok"), cheminImage="Images/32x32/Valider.png")
         self.bouton_annuler = CTRL_Bouton_image.CTRL(self, texte=_(u"Annuler"), cheminImage="Images/32x32/Annuler.png")
         # Propriétés
-        self.bouton_aide.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour obtenir de l'aide")))
-        self.bouton_options.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour définir les paramètres d'affichage de la fenêtre")))
-        self.bouton_outils.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour accéder aux outils")))
-        self.bouton_annuler.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour fermer")))
+        self.bouton_aide.SetToolTip(wx.ToolTip(
+            _(u"Cliquez ici pour obtenir de l'aide")
+        ))
+        self.bouton_options.SetToolTip(wx.ToolTip(
+            _(u"Cliquez ici pour définir les paramètres d'affichage de la fenêtre")
+        ))
+        self.bouton_outils.SetToolTip(wx.ToolTip(
+            _(u"Cliquez ici pour accéder aux outils")
+        ))
+        self.bouton_annuler.SetToolTip(wx.ToolTip(
+            _(u"Cliquez ici pour fermer")
+        ))
 
         # Layout
         sizer_base = wx.BoxSizer(wx.VERTICAL)
@@ -475,50 +499,95 @@ class Dialog(wx.Dialog):
 
         # Création des panels amovibles
         self.panel_commandes = Commandes(self)
-        self._mgr.AddPane(self.panel_commandes, aui.AuiPaneInfo().
-                          Name("commandes").Caption(_(u"Commandes")).
-                          Bottom().Layer(0).Position(1).CaptionVisible(False).CloseButton(False).MaximizeButton(False).MinSize((-1, 50)))
+        self._mgr.AddPane(self.panel_commandes, (
+            aui.AuiPaneInfo()
+               .Name("commandes").Caption(_(u"Commandes"))
+               .Bottom().Layer(0).Position(1)
+               .CaptionVisible(False).CloseButton(False).MaximizeButton(False)
+               .MinSize((-1, 50))
+        ))
 
-        self.panel_totaux = CTRL_Grille_totaux.CTRL(self, grille=self.panel_grille.grille)
-        self._mgr.AddPane(self.panel_totaux, aui.AuiPaneInfo().
-                          Name("totaux").Caption(_(u"Totaux")).
-                          Bottom().Layer(0).Position(0).Row(1).CloseButton(False).MaximizeButton(False).MinSize((160, 100)))
+        self.panel_totaux = CTRL_Grille_totaux.CTRL(
+            self, grille=self.panel_grille.grille,
+        )
+        self._mgr.AddPane(self.panel_totaux, (
+            aui.AuiPaneInfo()
+               .Name("totaux").Caption(_(u"Totaux"))
+               .Bottom().Layer(0).Position(0).Row(1)
+               .CloseButton(False).MaximizeButton(False)
+               .MinSize((160, 100))
+        ))
 
         self.panel_calendrier = CTRL_Grille_calendrier.CTRL(self)
-        self._mgr.AddPane(self.panel_calendrier, aui.AuiPaneInfo().
-                          Name("calendrier").Caption(_(u"Sélection de la date")).
-                          Left().Layer(1).BestSize(wx.Size(195, 180)).Position(1).CloseButton(False).Fixed().MaximizeButton(False))
+        self._mgr.AddPane(self.panel_calendrier, (
+            aui.AuiPaneInfo()
+               .Name("calendrier").Caption(_(u"Sélection de la date"))
+               .Left().Layer(1).Position(0)
+               .CloseButton(False).MaximizeButton(False)
+               .BestSize(wx.Size(195, 180)).Fixed()
+        ))
 
         self.panel_activites = CTRL_Grille_activite3.CTRL(self)
-        self._mgr.AddPane(self.panel_activites, aui.AuiPaneInfo().
-                          Name("activites").Caption(_(u"Sélection des activités")).
-                          Left().Layer(1).Position(1).CloseButton(False).MaximizeButton(False).BestSize(wx.Size(-1,50)))
-        pi = self._mgr.GetPane("activites")
-        pi.dock_proportion = 100000 # Proportion
+        self._mgr.AddPane(self.panel_activites, (
+            aui.AuiPaneInfo()
+               .Name("activites").Caption(_(u"Sélection des activités"))
+               .Left().Layer(1).Position(1)
+               .CloseButton(False).MaximizeButton(False)
+               .BestSize(wx.Size(-1, 50))
+        ))
+        self._mgr.GetPane("activites").dock_proportion = 100000
 
-        self.panel_legende = OL_Legende_grille.ListView(self, id=-1, name="OL_legende", style=wx.LC_REPORT|wx.LC_NO_HEADER | wx.SUNKEN_BORDER|wx.LC_SINGLE_SEL)
+        self.panel_legende = OL_Legende_grille.ListView(
+            self, id=-1, name="OL_legende", style=(
+                wx.LC_REPORT | wx.LC_NO_HEADER |
+                wx.SUNKEN_BORDER | wx.LC_SINGLE_SEL
+            ),
+        )
         self.panel_legende.SetSize((50, 50))
-        self._mgr.AddPane(self.panel_legende, aui.AuiPaneInfo().
-                          Name("legende").Caption(_(u"Légende")).
-                          Left().Layer(1).Position(2).CloseButton(False).MaximizeButton(False).MinSize((160, 100)).MaxSize((-1, 120)) )
+        self._mgr.AddPane(self.panel_legende, (
+            aui.AuiPaneInfo()
+               .Name("legende").Caption(_(u"Légende"))
+               .Left().Layer(1).Position(2)
+               .CloseButton(False).MaximizeButton(False)
+               .MinSize((160, 100)).MaxSize((-1, 120))
+        ))
 
-        self.panel_raccourcis = OL_Raccourcis_grille.ListView(self, id=-1, name="OL_raccourcis", style=wx.LC_REPORT|wx.LC_NO_HEADER | wx.SUNKEN_BORDER|wx.LC_SINGLE_SEL)
+        self.panel_raccourcis = OL_Raccourcis_grille.ListView(
+            self, id=-1, name="OL_raccourcis", style=(
+                wx.LC_REPORT | wx.LC_NO_HEADER |
+                wx.SUNKEN_BORDER | wx.LC_SINGLE_SEL
+            ),
+        )
         self.panel_raccourcis.SetSize((50, 50))
-        self._mgr.AddPane(self.panel_raccourcis, aui.AuiPaneInfo().
-                          Name("raccourcis").Caption(_(u"Touches raccourcis")).
-                          Left().Layer(1).Position(3).CloseButton(False).MaximizeButton(False).MinSize((160, 100)).MaxSize((-1, 120)) )
+        self._mgr.AddPane(self.panel_raccourcis, (
+            aui.AuiPaneInfo()
+               .Name("raccourcis").Caption(_(u"Touches raccourcis"))
+               .Left().Layer(1).Position(3)
+               .CloseButton(False).MaximizeButton(False)
+               .MinSize((160, 100)).MaxSize((-1, 120))
+        ))
         self._mgr.GetPane("raccourcis").dock_proportion = 60000
 
         self.panel_etiquettes = CTRL_Etiquettes.CTRL(self, activeMenu=False)
-        self._mgr.AddPane(self.panel_etiquettes, aui.AuiPaneInfo().
-                          Name("etiquettes").Caption(_(u"Etiquettes")).
-                          Right().Layer(0).Position(0).CloseButton(False).BestSize(wx.Size(275, 100)).MaximizeButton(False).MinSize((275, 100)))
+        self._mgr.AddPane(self.panel_etiquettes, (
+            aui.AuiPaneInfo()
+               .Name("etiquettes").Caption(_(u"Etiquettes"))
+               .Right().Layer(0).Position(0)
+               .CloseButton(False).MaximizeButton(False)
+               .BestSize(wx.Size(275, 100)).MinSize((275, 100))
+        ))
         self._mgr.GetPane("etiquettes").Hide()
 
-        self.panel_forfaits = CTRL_Grille_forfaits.CTRL(self, grille=self.panel_grille.grille)
-        self._mgr.AddPane(self.panel_forfaits, aui.AuiPaneInfo().
-                          Name("forfaits").Caption(_(u"Forfaits crédits")).
-                          Right().Layer(0).Position(1).BestSize(wx.Size(275,140)).Position(4).CloseButton(False).MaximizeButton(False).MinSize((275, 100)))
+        self.panel_forfaits = CTRL_Grille_forfaits.CTRL(
+            self, grille=self.panel_grille.grille
+        )
+        self._mgr.AddPane(self.panel_forfaits, (
+            aui.AuiPaneInfo()
+               .Name("forfaits").Caption(_(u"Forfaits crédits"))
+               .Right().Layer(0).Position(1)
+               .CloseButton(False).MaximizeButton(False)
+               .BestSize(wx.Size(275, 140)).MinSize((275, 100))
+        ))
         self._mgr.GetPane("forfaits").Hide()
 
         # Création du panel central
@@ -558,7 +627,10 @@ class Dialog(wx.Dialog):
 #        self.SetDate(date)
 
         # Init
-        self.panel_activites.SetCocherParDefaut(UTILS_Config.GetParametre("gestionnaire_conso_cocher_activites", defaut=True))
+        self.panel_activites.SetCocherParDefaut(
+            UTILS_Config.GetParametre("gestionnaire_conso_cocher_activites",
+                                      defaut=True)
+        )
 
         # Affichage du panneau du panneau Forfait Credits
 #        if self.panel_grille.grille.tarifsForfaitsCreditsPresents == True :
@@ -779,12 +851,17 @@ class Dialog(wx.Dialog):
         menuPop.AppendSeparator()
 
         self.listePanneaux = [
-            { "label": _(u"Sélection de la date"), "code": "calendrier", "IDmenu": None },
-            { "label": _(u"Sélection des activités"), "code": "activites", "IDmenu": None },
-            { "label": _(u"Légende"), "code": "legende", "IDmenu": None },
-            { "label": _(u"Touches raccourcis"), "code": "raccourcis", "IDmenu": None },
-            { "label": _(u"Totaux"), "code": "totaux", "IDmenu": None },
-            ]
+            {"label": _(u"Sélection de la date"),
+             "code": "calendrier", "IDmenu": None},
+            {"label": _(u"Sélection des activités"),
+             "code": "activites", "IDmenu": None},
+            {"label": _(u"Légende"),
+             "code": "legende", "IDmenu": None},
+            {"label": _(u"Touches raccourcis"),
+             "code": "raccourcis", "IDmenu": None},
+            {"label": _(u"Totaux"),
+             "code": "totaux", "IDmenu": None},
+        ]
         ID = ID_AFFICHAGE_PANNEAUX
         for dictPanneau in self.listePanneaux:
             dictPanneau["IDmenu"] = ID

--- a/noethys/Dlg/DLG_Gestionnaire_conso.py
+++ b/noethys/Dlg/DLG_Gestionnaire_conso.py
@@ -153,7 +153,7 @@ class Commandes(wx.Panel):
 
     def OnBoutonAnnuler(self, event):
         etat = self.parent.Annuler()
-        if etat == False:
+        if etat is False:
             return
         self.parent.EndModal(wx.ID_CANCEL)
 
@@ -308,7 +308,7 @@ class PanelGrille(wx.Panel):
 
     def SetDate(self, date=None):
         self.date = date
-        if self.date == None:
+        if self.date is None:
             dateStr = u""
         else:
             dateStr = DateComplete(self.date)
@@ -350,17 +350,17 @@ class PanelGrille(wx.Panel):
             listeSelectionIndividus.append(IDindividu)
 
         # On ajoute les individus ajoutés manuellement :
-        if self.dictIndividusAjoutes.has_key(self.date):
+        if self.date in self.dictIndividusAjoutes:
             for IDindividu in self.dictIndividusAjoutes[self.date]:
                 valide = False
-                if self.grille.dictConsoIndividus.has_key(IDindividu):
-                    if self.grille.dictConsoIndividus[IDindividu].has_key(self.date):
+                if IDindividu in self.grille.dictConsoIndividus:
+                    if self.date in self.grille.dictConsoIndividus[IDindividu]:
                         # Vérifie que l'individu a des conso pour la ou les groupes sélectionnés
                         for IDunite, listeConso in self.grille.dictConsoIndividus[IDindividu][self.date].iteritems():
                             for conso in listeConso:
                                 if conso.IDgroupe in self.listeGroupes:
                                     valide = True
-                if valide == True and IDindividu not in listeSelectionIndividus:
+                if valide is True and IDindividu not in listeSelectionIndividus:
                     listeSelectionIndividus.append(IDindividu)
 
         return listeSelectionIndividus
@@ -378,12 +378,12 @@ class PanelGrille(wx.Panel):
                 dlg.Destroy()
                 return
         dlg.Destroy()
-        if IDindividu == None:
+        if IDindividu is None:
             return
         self.listeSelectionIndividus.append(IDindividu)
         self.grille.SetModeDate(self.listeActivites, self.listeSelectionIndividus, self.date)
         # Ajout de l'individu dans une liste pour le garder afficher lors d'une MAJ de l'affichage
-        if self.dictIndividusAjoutes.has_key(self.date) == False:
+        if self.date not in self.dictIndividusAjoutes:
             self.dictIndividusAjoutes[self.date] = []
         if IDindividu not in self.dictIndividusAjoutes[self.date]:
             self.dictIndividusAjoutes[self.date].append(IDindividu)
@@ -419,7 +419,7 @@ class PanelGrille(wx.Panel):
             if IDindividu not in self.listeSelectionIndividus:
                 self.listeSelectionIndividus.append(IDindividu)
                 # Ajout de l'individu dans une liste pour le garder afficher lors d'une MAJ de l'affichage
-                if self.dictIndividusAjoutes.has_key(self.date) == False:
+                if self.date not in self.dictIndividusAjoutes:
                     self.dictIndividusAjoutes[self.date] = []
                 if IDindividu not in self.dictIndividusAjoutes[self.date]:
                     self.dictIndividusAjoutes[self.date].append(IDindividu)
@@ -446,7 +446,7 @@ class Dialog(wx.Dialog):
         # Détermine la taille de la fenêtre
         self.SetMinSize((700, 600))
         taille_fenetre = UTILS_Config.GetParametre("taille_fenetre_tableau_presences")
-        if taille_fenetre == None:
+        if taille_fenetre is None:
             self.SetSize((900, 600))
         if taille_fenetre == (0, 0):
             self.Maximize(True)
@@ -457,11 +457,11 @@ class Dialog(wx.Dialog):
         # Récupère les perspectives
         cfg = UTILS_Config.FichierConfig()
         self.userConfig = cfg.GetDictConfig()
-        if self.userConfig.has_key("gestionnaire_perspectives") == True:
+        if "gestionnaire_perspectives" in self.userConfig:
             self.perspectives = self.userConfig["gestionnaire_perspectives"]
         else:
             self.perspectives = []
-        if self.userConfig.has_key("gestionnaire_perspective_active") == True:
+        if "gestionnaire_perspective_active" in self.userConfig:
             self.perspective_active = self.userConfig["gestionnaire_perspective_active"]
         else:
             self.perspective_active = None
@@ -530,19 +530,19 @@ class Dialog(wx.Dialog):
         self.perspective_defaut = self._mgr.SavePerspective()
 
         # Récupération de la perspective chargée
-        if self.perspective_active != None:
+        if self.perspective_active is not None:
             self._mgr.LoadPerspective(self.perspectives[self.perspective_active]["perspective"])
         else:
             self._mgr.LoadPerspective(self.perspective_defaut)
 
         # Affichage du panneau du panneau Forfait Credits
-        if self.panel_grille.grille.tarifsForfaitsCreditsPresents == True:
+        if self.panel_grille.grille.tarifsForfaitsCreditsPresents is True:
             self._mgr.GetPane("forfaits").Show()
         else:
             self._mgr.GetPane("forfaits").Hide()
 
         # Affichage du panneau du panneau Etiquettes
-        if self.panel_grille.grille.afficherListeEtiquettes == True:
+        if self.panel_grille.grille.afficherListeEtiquettes is True:
             self._mgr.GetPane("etiquettes").Show()
         else:
             self._mgr.GetPane("etiquettes").Hide()
@@ -615,7 +615,7 @@ class Dialog(wx.Dialog):
     def OnClose(self, event):
         self.MemoriseParametres()
         etat = self.Annuler()
-        if etat == False:
+        if etat is False:
             return
         event.Skip()
 
@@ -735,7 +735,7 @@ class Dialog(wx.Dialog):
         dlg.Destroy()
 
     def On_outils_recalculer(self, event):
-        if UTILS_Utilisateurs.VerificationDroitsUtilisateurActuel("consommations_conso", "modifier") == False:
+        if UTILS_Utilisateurs.VerificationDroitsUtilisateurActuel("consommations_conso", "modifier") is False:
             return
         dlg = wx.MessageDialog(self, _(u"Confirmez-vous le recalcul des prestations de toutes les consommations affichées ?"), _(u"Recalcul des prestations"), wx.YES_NO|wx.NO_DEFAULT|wx.CANCEL|wx.ICON_QUESTION)
         reponse = dlg.ShowModal()
@@ -751,7 +751,7 @@ class Dialog(wx.Dialog):
         item = wx.MenuItem(menuPop, ID_AFFICHAGE_PERSPECTIVE_DEFAUT, _(u"Disposition par défaut"), _(u"Afficher la disposition par défaut"), wx.ITEM_CHECK)
         menuPop.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.On_affichage_perspective_defaut, id=ID_AFFICHAGE_PERSPECTIVE_DEFAUT)
-        if self.perspective_active == None:
+        if self.perspective_active is None:
             item.Check(True)
 
         index = 0


### PR DESCRIPTION
Pour comprendre un peu mieux l'origine de cette PR, voici un peu de contexte...

L'un de nos usagers utilise Noethys pour la restauration scolaire d'une commune, avec un pointage papier - c'est-à-dire que l'état de pointage est généré par Noethys, rempli par le personnel de cantine chaque jour et ensuite saisi dans Noethys. À la cantine, comme c'est le cas généralement, le passage des élèves se fait par classe (dans leur cas, il y a en plus plusieurs écoles et plusieurs cantines). L'état de pointage est donc généré en regroupant les inscrit-e-s par classe, comme le permets très bien Noethys, vu que la scolarité est renseignée pour chaque individu.
Là où les choses se compliquent, c'est au moment de la saisie dans Noethys, puisque dans le gestionnaire de consommations, on retrouve juste l'ensemble des inscrit-e-s pour le jour. En essayant de trouver un moyen de faciliter cette longue saisie fastidieuse (il y a ~400 enfants), nous sommes partis vers essayer d'avoir quasiment la même vue dans le gestionnaire de consommations qu'avec ce qui est généré à l'état de pointage.

----

Cette PR ajoute un nouveau panneau dans le gestionnaire de consommations qui permets de filtrer les inscrit-e-s par école/classe. Pour ne pas modifier le comportement actuel, ce panneau est par défaut masqué - et donc désactivé. Enfin, comme désormais pour les activités, la sélection est maintenue à chaque changement de date. Pour ce faire, j'ai factorisé un peu la construction de la clause `WHERE` de la grille dans https://github.com/jeromelebleu/Noethys/commit/ea46556b588d4a28bd199834448f4edf511ff09f, après m'être permis un peu de nettoyage suivant la PEP8...

Est-ce que cela vous convient comme changement ?

Merci d'avance !