### PR TITLE
Ajouter la catégorie "autre" à la prestation négative de remboursement

### DIFF
--- a/noethys/Dlg/DLG_Inscription.py
+++ b/noethys/Dlg/DLG_Inscription.py
@@ -500,6 +500,7 @@ class Dialog(wx.Dialog):
                 ("IDactivite", IDactivite),
                 ("IDfamille", IDfamille),
                 ("IDindividu", self.IDindividu),
+                ("categorie", "autre"),
                 ("date_valeur", str(datetime.date.today())),
             ]
             DB.ReqInsert("prestations", listeDonnees)


### PR DESCRIPTION
Cela fixe un message d'erreur qui aparaissait lorsqu'on consultait la fiche de consomation d'une famille avec une activité remousée suite à une désinscription.

Fixes #44