### PR TITLE
Fix export des nombres decimaux dans Excel

### DIFF
--- a/noethys/Utils/UTILS_Questionnaires.py
+++ b/noethys/Utils/UTILS_Questionnaires.py
@@ -130,7 +130,7 @@ class Questionnaires():
             else :
                 texteReponse = _(u"Non")
         if filtre == "date" : texteReponse = DateEngEnDateDD(reponse)
-        if filtre == "decimal": texteReponse = reponse
+        if filtre == "decimal": texteReponse = float(reponse)
         return texteReponse
 
 


### PR DESCRIPTION
Le dernier fix permet d'afficher correctement les nombre décimaux dans les listes d'inscriptions, mais lors de l'export vers Excel ces nombres sont considérés comme du texte et Excel ne peux pas faire d'opérations mathématiques dessus.

Cette correction répare ce problème.