### PR TITLE
feat: affiche les valeurs par défaut aux questions non répondues

### DIFF
--- a/noethys/Utils/UTILS_Infos_individus.py
+++ b/noethys/Utils/UTILS_Infos_individus.py
@@ -866,6 +866,9 @@ class Informations() :
         """ Attribue les valeurs en tant que attribut à un module. Sert pour les tracks des objectlistview """
         dictDonnees = self.GetDictValeurs(mode=mode, ID=ID, formatChamp=False)
         for code, valeur in dictDonnees.items():
+            if valeur is None and code.startswith("QUESTION_"):
+                question = next((q for q in dictDonnees["questionnaires"] if q["champ"] == '{%s}' % code), None)
+                if question: valeur = question["textDefaut"]
             setattr(parent, code, valeur)
     
     def StockageTable(self, mode="famille"):

--- a/noethys/Utils/UTILS_Questionnaires.py
+++ b/noethys/Utils/UTILS_Questionnaires.py
@@ -38,7 +38,7 @@ def GetReponse(dictReponses={}, IDquestion=None, ID=None):
     if IDquestion in dictReponses :
         if ID in dictReponses[IDquestion] :
             return dictReponses[IDquestion][ID]
-    return u""
+    return None
 
 def FormateDate(date):
     if date in (None, "") : return ""
@@ -154,7 +154,8 @@ class Questionnaires():
         listeResultats = []
         for IDquestion, label, type, controle, defaut in listeQuestions :
             if avec_filtre == False or self.GetFiltre(controle) != None :
-                listeResultats.append({"IDquestion":IDquestion, "label":label, "type":type, "controle":controle, "defaut":defaut, "filtre":self.GetFiltre(controle)})
+                textDefaut = self.FormatageReponse(defaut, controle)
+                listeResultats.append({"IDquestion":IDquestion, "label":label, "type":type, "controle":controle, "defaut":defaut, "textDefaut": textDefaut, "filtre":self.GetFiltre(controle)})
         return listeResultats
 
 
@@ -239,7 +240,8 @@ class ChampsEtReponses():
             champ = "{QUESTION_%d}" % dictQuestion["IDquestion"]
             dictReponse = {
                 "champ":champ, "reponse":reponse, "IDquestion":dictQuestion["IDquestion"], "label":dictQuestion["label"], 
-                "type":dictQuestion["type"], "controle":dictQuestion["controle"], "defaut":dictQuestion["defaut"]
+                "type":dictQuestion["type"], "controle":dictQuestion["controle"], "defaut":dictQuestion["defaut"],
+                "textDefaut": dictQuestion["textDefaut"]
                 }
             listeDonnees.append(dictReponse)
         return listeDonnees


### PR DESCRIPTION
Dans les exports de données, pour les colonnes correspondant à une
question de questionnaire, si aucune réponse n'est enregistrée pour
l'individu/famille/donnée, la réponse par défaut (de la table questions)
s'affiche au lieu d'une case vide.